### PR TITLE
Speedometer Sensor

### DIFF
--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -5,10 +5,12 @@
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
 @persist Trucks:array
+@persist Speedo:table SpeedRaw
 
 if (first() | duped())
 {
     #include "e2shared/RailDriver/lib/smartEntityManagement"
+    #include "e2shared/RailDriver/lib/sensors/speedometer"
     #include "e2shared/RailDriver/lib/pidf"
 
     semLockE2()
@@ -19,9 +21,18 @@ if (first() | duped())
         assert(Trucks:count() == 2, "No trucks were found.")
         assert((Trucks[1, entity]:isValid() & Trucks[1, entity]:isValidPhysics()), "Front truck entity data is invalid.")
         assert((Trucks[2, entity]:isValid() & Trucks[2, entity]:isValidPhysics()), "Rear truck entity data is invalid.")
+
+        Speedo = speedoCreateInstance(Trucks[1, entity], Trucks[2, entity])
+        speedoStartTimer(Speedo)
     }
 
     runOnTick(1)
+}
+
+if (clk(speedoGetClockId(Speedo)))
+{
+    speedoClearAndRestartTimer(Speedo)
+    SpeedRaw = speedoGetSpeed(Speedo, 1)
 }
 
 if (tickClk())

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -4,10 +4,23 @@
 
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
+@persist Trucks:array
 
 if (first() | duped())
 {
+    #include "e2shared/RailDriver/lib/smartEntityManagement"
     #include "e2shared/RailDriver/lib/pidf"
+
+    semLockE2()
+
+    if (semSmartParentE2toLocoBody() == 1)
+    {
+        Trucks = semSmartDiscoverLocoTrucks()
+        assert(Trucks:count() == 2, "No trucks were found.")
+        assert((Trucks[1, entity]:isValid() & Trucks[1, entity]:isValidPhysics()), "Front truck entity data is invalid.")
+        assert((Trucks[2, entity]:isValid() & Trucks[2, entity]:isValidPhysics()), "Rear truck entity data is invalid.")
+    }
+
     runOnTick(1)
 }
 

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -193,6 +193,12 @@ function number speedoDataIsValid(S:table)
 {
     return S["SPEEDOMETER FAULT: Speed Data Invalid", number] == 0 ? 1 : 0
 }
+
+function number speedoGetRawPositiveInput(S:table)
+{
+    return -S["Differential Speed Positive Input", entity]:velL():y()
+}
+
 function number speedoGetRawNegativeInput(S:table)
 {
     return -S["Differential Speed Negative Input", entity]:velL():y()

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -4,3 +4,21 @@
 ]#
 
 @name RailDriver/lib/sensors/speedometer
+
+function table speedoCreateInstance(InputPos:entity, InputNeg:entity)
+{
+    local S:table()
+    S:clear()
+    S["Clock Name", string] = "Speedometer"
+    S["Clock Sampling Rate", number] = 100
+    S["Differential Speed Positive Input", entity] = InputPos
+    S["Differential Speed Negative Input", entity] = InputNeg
+
+    S["Error Threshold", number] = 1.5
+    S["Error Hysteresis", number] = (5 / 100) * S["Error Threshold", number]
+    S["Error Hyst. High", number] = S["Error Threshold", number] + S["Error Hysteresis", number]
+    S["Error Hyst. Low", number] = S["Error Threshold", number] - S["Error Hysteresis", number]
+
+    S["Speed Data is Valid Flag", number] = 0
+    return S
+}

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -22,3 +22,26 @@ function table speedoCreateInstance(InputPos:entity, InputNeg:entity)
     S["Speed Data is Valid Flag", number] = 0
     return S
 }
+
+function number speedoSetSampleRate(S:table, ClockName:string, SampleRateMillis)
+{
+    local TimersInUse = getTimers()
+
+    for (I = 1, TimersInUse:count())
+    {
+        if (TimersInUse[I, string] == ClockName)
+        {
+            return 0
+        }
+    }
+
+    if (SampleRateMillis < (tickInterval() * 1000))
+    {
+        return 0
+    }
+
+    S["Clock Name", string] = ClockName
+    S["Clock Sampling Rate", number] = SampleRateMillis
+
+    return 1
+}

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -45,3 +45,8 @@ function number speedoSetSampleRate(S:table, ClockName:string, SampleRateMillis)
 
     return 1
 }
+
+function void speedoStartTimer(S:table)
+{
+    timer(S["Clock Name", string], S["Clock Sampling Rate", number])
+}

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -179,7 +179,5 @@ function number speedoGetSpeed(S:table, Direction)
         }
     }
 
-    # [TO-DO]: Linear interpolation between values.
-
     return Output
 }

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -18,8 +18,13 @@ function table speedoCreateInstance(InputPos:entity, InputNeg:entity)
     S["Error Hysteresis", number] = (5 / 100) * S["Error Threshold", number]
     S["Error Hyst. High", number] = S["Error Threshold", number] + S["Error Hysteresis", number]
     S["Error Hyst. Low", number] = S["Error Threshold", number] - S["Error Hysteresis", number]
+    S["!Error Hyst. High", number] = -S["Error Hyst. High", number]
+    S["!Error Hyst. Low", number] = -S["Error Hyst. Low", number]
 
-    S["Speed Data is Valid Flag", number] = 0
+    S["SPEEDOMETER FAULT: Speed Data Invalid", number] = 0
+    S["SPEEDOMETER FAULT: Speed Data Invalid Latch", number] = 0
+    S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] = 0
+    S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] = 0
     return S
 }
 
@@ -62,28 +67,116 @@ function void speedoClearAndRestartTimer(S:table)
     timer(S["Clock Name", string], S["Clock Sampling Rate", number])
 }
 
-function number speedoGetSpeed(S:table)
+function number speedoGetSpeed(S:table, Direction)
 {
     # Differential inputs to speedometer.
     local InPos = S["Differential Speed Positive Input", entity]:velL():y()
     local InNeg = S["Differential Speed Negative Input", entity]:velL():y()
-    local Delta = InPos + InNeg
 
-    # An error is derived from the differential inputs.
-    local Error = abs(Delta)
-    local Output = 0
-
-    Output = (InPos - InNeg) / 2
-
-    # The error needs to be relatively small in order for the speedometer's data to be valid.
-    if (Error <= 1.0)
+    # Differential inputs are inverted in reverse.
+    if (Direction < 0)
     {
-        S["Speed Data is Valid Flag", number] = 1
+        InPos = -InPos
+        InNeg = -InNeg
     }
 
-    else
+    # An error is derived from the differential inputs.
+    # This error needs to be relatively small in order for the speedometer's data to be valid.
+    local Error = abs(InPos + InNeg)
+
+    # Speed data is calculated from the differential inputs.
+    local Output = 0
+    Output = (InPos - InNeg) / 2
+
+    # Locomotive's direction needs to be correctly set.
+    # If the locomotive's direction is not correctly set, this will trigger a latching fault.
+    # This fault will remain asserted for the entire time that the locomotive is moving in the direction opposite to what it was set to.
+    # This can help with reporting rollback runaways to the rest of RailDriver.
+    switch (Direction)
     {
-        S["Speed Data is Valid Flag", number] = 0
+        # Trip the fault when the direction is set for reverse.
+        case -1,
+            if (Output > S["Error Hyst. High", number] & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 0)
+            {
+                if (S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] == 0 & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 0)
+                {
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] = 1
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] = 1
+                }
+            }
+
+            elseif (Output <= S["Error Hyst. Low", number] & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 1)
+            {
+                if (S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] == 1 & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 1)
+                {
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] = 0
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] = 0
+                }
+            }
+        break
+
+        # Trip the fault when neutral is detected.
+        case 0,
+            if ((Output > S["Error Hyst. High", number] | Output < S["!Error Hyst. High", number]) & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 0)
+            {
+                if (S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] == 0 & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 0)
+                {
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] = 1
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] = 1
+                }
+            }
+
+            elseif ((Output <= S["Error Hyst. Low", number] | Output >= S["!Error Hyst. Low", number]) & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 0)
+            {
+                if (S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] == 1 & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 1)
+                {
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] = 0
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] = 0
+                }
+            }
+        break
+
+        # Trip the fault when the direction is set for forwards.
+        case 1,
+            if (Output < S["!Error Hyst. High", number] & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 0)
+            {
+                if (S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] == 0 & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 0)
+                {
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] = 1
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] = 1
+                }
+            }
+
+            elseif (Output >= S["!Error Hyst. Low", number] & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 1)
+            {
+                if (S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] == 1 & S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] == 1)
+                {
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] = 0
+                    S["SPEEDOMETER FAULT: Speed Direction Incorrect Latch", number] = 0
+                }
+            }
+        break
+    }
+
+    # Speed error needs to be relatively small for the speedometer's data to be valid.
+    # When this error gets too large, it trips a latching fault condition.
+    # This fault will remain asserted until the error is reduced back to a small size again.
+    if (Error > S["Error Hyst. High", number] & S["SPEEDOMETER FAULT: Speed Data Invalid Latch", number] == 0)
+    {
+        if (S["SPEEDOMETER FAULT: Speed Data Invalid", number] == 0 & S["SPEEDOMETER FAULT: Speed Data Invalid Latch", number] == 0)
+        {
+            S["SPEEDOMETER FAULT: Speed Data Invalid", number] = 1
+            S["SPEEDOMETER FAULT: Speed Data Invalid Latch", number] = 1
+        }
+    }
+
+    elseif (Error <= S["Error Hyst. Low", number] & S["SPEEDOMETER FAULT: Speed Data Invalid Latch", number] == 1)
+    {
+        if (S["SPEEDOMETER FAULT: Speed Data Invalid", number] == 1 & S["SPEEDOMETER FAULT: Speed Data Invalid Latch", number] == 1)
+        {
+            S["SPEEDOMETER FAULT: Speed Data Invalid", number] = 0
+            S["SPEEDOMETER FAULT: Speed Data Invalid Latch", number] = 0
+        }
     }
 
     # [TO-DO]: Linear interpolation between values.

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -55,3 +55,9 @@ function string speedoGetClockId(S:table)
 {
     return S["Clock Name", string]
 }
+
+function void speedoClearAndRestartTimer(S:table)
+{
+    stoptimer(S["Clock Name", string])
+    timer(S["Clock Name", string], S["Clock Sampling Rate", number])
+}

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -50,3 +50,8 @@ function void speedoStartTimer(S:table)
 {
     timer(S["Clock Name", string], S["Clock Sampling Rate", number])
 }
+
+function string speedoGetClockId(S:table)
+{
+    return S["Clock Name", string]
+}

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -7,7 +7,7 @@
 
 function table speedoCreateInstance(InputPos:entity, InputNeg:entity)
 {
-    local S:table()
+    local S = table()
     S:clear()
     S["Clock Name", string] = "Speedometer"
     S["Clock Sampling Rate", number] = 100

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -14,6 +14,7 @@ function table speedoCreateInstance(InputPos:entity, InputNeg:entity)
     S["Differential Speed Positive Input", entity] = InputPos
     S["Differential Speed Negative Input", entity] = InputNeg
 
+    S["Error Value", number] = 0
     S["Error Threshold", number] = 1.5
     S["Error Hysteresis", number] = (5 / 100) * S["Error Threshold", number]
     S["Error Hyst. High", number] = S["Error Threshold", number] + S["Error Hysteresis", number]
@@ -83,6 +84,7 @@ function number speedoGetSpeed(S:table, Direction)
     # An error is derived from the differential inputs.
     # This error needs to be relatively small in order for the speedometer's data to be valid.
     local Error = abs(InPos + InNeg)
+    S["Error Value", number] = Error
 
     # Speed data is calculated from the differential inputs.
     local Output = 0
@@ -190,4 +192,8 @@ function number speedoDirectionIsValid(S:table)
 function number speedoDataIsValid(S:table)
 {
     return S["SPEEDOMETER FAULT: Speed Data Invalid", number] == 0 ? 1 : 0
+}
+function number speedoGetDifferentialError(S:table)
+{
+    return S["Error Value", number]
 }

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -181,3 +181,8 @@ function number speedoGetSpeed(S:table, Direction)
 
     return Output
 }
+
+function number speedoDirectionIsValid(S:table)
+{
+    return S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] == 0 ? 1 : 0
+}

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -186,3 +186,8 @@ function number speedoDirectionIsValid(S:table)
 {
     return S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] == 0 ? 1 : 0
 }
+
+function number speedoDataIsValid(S:table)
+{
+    return S["SPEEDOMETER FAULT: Speed Data Invalid", number] == 0 ? 1 : 0
+}

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -61,3 +61,32 @@ function void speedoClearAndRestartTimer(S:table)
     stoptimer(S["Clock Name", string])
     timer(S["Clock Name", string], S["Clock Sampling Rate", number])
 }
+
+function number speedoGetSpeed(S:table)
+{
+    # Differential inputs to speedometer.
+    local InPos = S["Differential Speed Positive Input", entity]:velL():y()
+    local InNeg = S["Differential Speed Negative Input", entity]:velL():y()
+    local Delta = InPos + InNeg
+
+    # An error is derived from the differential inputs.
+    local Error = abs(Delta)
+    local Output = 0
+
+    Output = (InPos - InNeg) / 2
+
+    # The error needs to be relatively small in order for the speedometer's data to be valid.
+    if (Error <= 1.0)
+    {
+        S["Speed Data is Valid Flag", number] = 1
+    }
+
+    else
+    {
+        S["Speed Data is Valid Flag", number] = 0
+    }
+
+    # [TO-DO]: Linear interpolation between values.
+
+    return Output
+}

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -71,8 +71,8 @@ function void speedoClearAndRestartTimer(S:table)
 function number speedoGetSpeed(S:table, Direction)
 {
     # Differential inputs to speedometer.
-    local InPos = S["Differential Speed Positive Input", entity]:velL():y()
-    local InNeg = S["Differential Speed Negative Input", entity]:velL():y()
+    local InPos = -S["Differential Speed Positive Input", entity]:velL():y()
+    local InNeg = -S["Differential Speed Negative Input", entity]:velL():y()
 
     # Differential inputs are inverted in reverse.
     if (Direction < 0)

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -181,7 +181,7 @@ function number speedoGetSpeed(S:table, Direction)
         }
     }
 
-    return Output
+    return abs(Output)
 }
 
 function number speedoDirectionIsValid(S:table)

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -193,6 +193,11 @@ function number speedoDataIsValid(S:table)
 {
     return S["SPEEDOMETER FAULT: Speed Data Invalid", number] == 0 ? 1 : 0
 }
+function number speedoGetRawNegativeInput(S:table)
+{
+    return -S["Differential Speed Negative Input", entity]:velL():y()
+}
+
 function number speedoGetDifferentialError(S:table)
 {
     return S["Error Value", number]

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -1,0 +1,6 @@
+#[
+    This file is a part of the RailDriver project.
+    Copyright © 2022, Cassandra "ZZ Cat" Robinson. All rights reserved.
+]#
+
+@name RailDriver/lib/sensors/speedometer

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -48,7 +48,7 @@ function array semSmartDiscoverLocoTrucks()
 {
     local E = entity()
     local P = E:parent()
-    local CE = getConnectedEntities("axis")
+    local CE = P:getConnectedEntities("axis")
 
     if (!CE[1, entity] | !CE[1, entity]:isValid())
     {

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -5,3 +5,22 @@
 
 @name RailDriver/lib/smartEntityManagement
 
+function void semLockE2()
+{
+    local E = entity()
+    local LockE2 = 0
+
+    if (isSinglePlayer() != 0)
+    {
+        LockE2 = 0
+    }
+
+    else
+    {
+        LockE2 = 1
+    }
+
+    E:propNotSolid(LockE2)
+    E:propDraw(!LockE2)
+    E:propShadow(!LockE2)
+}

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -1,0 +1,7 @@
+#[
+    This file is a part of the RailDriver project.
+    Copyright © 2022, Cassandra "ZZ Cat" Robinson. All rights reserved.
+]#
+
+@name RailDriver/lib/smartEntityManagement
+

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -43,3 +43,43 @@ function number semSmartParentE2toLocoBody()
 
     return 1
 }
+
+function array semSmartDiscoverLocoTrucks()
+{
+    local E = entity()
+    local P = E:parent()
+    local CE = getConnectedEntities("axis")
+
+    if (!CE[1, entity] | !CE[1, entity]:isValid())
+    {
+        return array()
+    }
+
+    else
+    {
+        CE:remove(1)
+        if (CE:count() == 0)
+        {
+            return array()
+        }
+
+        else
+        {
+            local Ret = array()
+            for (I = 1, CE:count())
+            {
+                if (P:toLocal(CE[I, entity]:pos()):x() < 0)
+                {
+                    Ret[1, entity] = CE[I, entity]
+                }
+
+                else
+                {
+                    Ret[2, entity] = CE[I, entity]
+                }
+            }
+
+            return Ret
+        }
+    }
+}

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -24,3 +24,22 @@ function void semLockE2()
     E:propDraw(!LockE2)
     E:propShadow(!LockE2)
 }
+
+function number semSmartParentE2toLocoBody()
+{
+    local E = entity()
+
+    if (!E:parent())
+    {
+        local W = E:isWeldedTo()
+        if (W:isValid() == 0 | !W)
+        {
+            return 0
+        }
+
+        E:constraintBreak("weld", W)
+        E:parentTo(W)
+    }
+
+    return 1
+}


### PR DESCRIPTION
This PR adds a speedometer sensor.
The speedometer uses differential inputs for detection of the locomotive's speed.
Differential Inputs will be taken directly from both of the locomotive's trucks. Ergo, the trucks need to be facing in their correct directions in order for the speedometer to do its thing.

The Speedometer Sensor has two latching fault flags. One for invalid speed data & the other flag is for when the sampled speed is not correct for the direction that the locomotive is traveling in.
This is good for detecting Rollback Runaways & the fault reporting system can be used to trigger other parts of RailDriver, such as Emergency Mode.

Sampling & thresholds are calculated & set at startup, rather than constantly calculating them during main operation.