### PR TITLE
Player Controls

### DIFF
--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -19,6 +19,7 @@
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
 @persist Trucks:array
+@persist Speedo:table SpeedRaw SpeedFiltered
 @outputs Debugger:table
 @strict
 
@@ -67,6 +68,7 @@ if (first() | duped())
         }
         #speedometerSetUnits(Speedo, "mph")
         #speedometerSetSmoothing(Speedo, 0.5)
+        speedometerSetFilterCutoffFrequency(Speedo, 10) 
         speedometerStart(Speedo)
 
         timer("Debug", 100)
@@ -78,15 +80,19 @@ if (first() | duped())
         # This prevents the E2 from being permanently locked.
         # This also prevents the E2 from being permanently parented to the locomotive.
         semUnlockE2()
-        semSmartUnparentE2FromLocoBody()
-        printColor(vec(255, 0, 0), "[RailDriver | Error]: ", vec(255, 255, 255), Exception)
+        semSmartUnparentE2fromLocoBody()
+        printColor(vec(255, 0, 0), "[RailDriver | Error]", vec(255, 255, 255), ": " + Exception)
     }
 }
 
-if (clk(speedoGetClockId(Speedo)))
+if (clk(speedometerGetClockId(Speedo)))
 {
-    speedoClearAndRestartTimer(Speedo)
-    SpeedRaw = speedoGetSpeed(Speedo, 1)
+    speedometerClearAndRestartTimer(Speedo)
+    SpeedRaw = speedometerGetSpeed(Speedo, 1)
+
+    # Apply a low-pass filter to the raw speed.
+    SpeedFiltered = speedometerFilter(Speedo, SpeedRaw)
+
 }
 
 if (tickClk())
@@ -97,4 +103,8 @@ if (clk("Debug"))
 {
     stoptimer("Debug")
     timer("Debug", 100)
+    Debugger["Speed Raw", number] = SpeedRaw
+    Debugger["Speed Filtered", number] = SpeedFiltered
+    Debugger["Speed Final", number] = SpeedFinal
+    Debugger["Speed Filter Cut-off Frequency (Hz)", number] = speedometerGetFilterCutOffFrequencyHz(Speedo)
 }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -19,13 +19,14 @@
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
 @persist Trucks:array
-@persist Speedo:table SpeedRaw
+@persist [PlayerControls ThrottleMap BrakeMap]:table TrainDriver:entity
 @strict
 
 if (first() | duped())
 {
     #include "e2shared/RailDriver/lib/smartEntityManagement"
     #include "e2shared/RailDriver/lib/sensors/speedometer"
+    #include "e2shared/RailDriver/lib/controls/playerControls"
     #include "e2shared/RailDriver/lib/pidf"
 
     try
@@ -69,6 +70,39 @@ if (first() | duped())
         #speedometerSetSmoothing(Speedo, 0.5)
         speedometerStart(Speedo)
 
+        # Setup throttle and brake maps.
+        ThrottleMap["Throttle Input Type", string] = "Velocity"
+        ThrottleMap["Velocity Setpoint", array] = array(0, 5, 15, 20, 30, 40, 60)
+        ThrottleMap["Acceleration Setpoint", array] = array(0, 0.5, 1, 1.5, 2, 2.5, 3)
+        BrakeMap["Brake Input Type", string] = "Velocity"
+        BrakeMap["Velocity Setpoint", array] = array(0, 5, 15, 20, 30, 40, 60)
+        BrakeMap["Deceleration Setpoint", array] = array(0, -0.5, -1, -1.5, -2, -2.5, -3)
+
+        # Setup default key bindings.
+        local KeyboardControls = table()
+        KeyboardControls["Increase Reverser", string] = "W"
+        KeyboardControls["Decrease Reverser", string] = "S"
+        KeyboardControls["Increase Throttle", string] = "D"
+        KeyboardControls["Decrease Throttle", string] = "A"
+        KeyboardControls["Increase Train Brake", string] = "left shift + D"
+        KeyboardControls["Decrease Train Brake", string] = "left shift + A"
+        KeyboardControls["Increase Engine Brake", string] = "left ctrl + D"
+        KeyboardControls["Decrease Engine Brake", string] = "left ctrl + A"
+        KeyboardControls["Emergency Brake", string] = "space"
+        KeyboardControls["Horn", string] = "H"
+        KeyboardControls["bell", string] = "left alt"
+        KeyboardControls["Headlights", string] = "F"
+        KeyboardControls["Ditch Lights", string] = "left shift + F"
+
+        # Set the driver to the player who spawned the E2.
+        TrainDriver = owner()
+
+        # Initialize and configure the player controls with keyboard controls, throttle and brake maps, and the driver.
+        PlayerControls = playerControlsInit(KeyboardControls, ThrottleMap, BrakeMap, TrainDriver)
+        if (!PlayerControls)
+        {
+            error("Failed to initialize player controls.")
+        }
     }
     catch (Exception)
     {
@@ -83,8 +117,11 @@ if (first() | duped())
 
 if (clk(speedoGetClockId(Speedo)))
 {
-    speedoClearAndRestartTimer(Speedo)
-    SpeedRaw = speedoGetSpeed(Speedo, 1)
+
+if (keyClk())
+{
+    # Update the player controls.
+    playerControlsUpdate(PlayerControls)
 }
 
 if (tickClk())

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -83,7 +83,7 @@ if (first() | duped())
         # This prevents the E2 from being permanently locked.
         # This also prevents the E2 from being permanently parented to the locomotive.
         semUnlockE2()
-        semSmartUnparentE2FromLocoBody()
+        semSmartUnparentE2fromLocoBody()
         printColor(vec(255, 0, 0), "[RailDriver | Error]: ", vec(255, 255, 255), Exception)
     }
 }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -19,7 +19,7 @@
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
 @persist Trucks:array
-@persist Speedo:table SpeedRaw
+@outputs Debugger:table
 @strict
 
 if (first() | duped())
@@ -69,6 +69,8 @@ if (first() | duped())
         #speedometerSetSmoothing(Speedo, 0.5)
         speedometerStart(Speedo)
 
+        timer("Debug", 100)
+
     }
     catch (Exception)
     {
@@ -89,4 +91,10 @@ if (clk(speedoGetClockId(Speedo)))
 
 if (tickClk())
 {
+}
+
+if (clk("Debug"))
+{
+    stoptimer("Debug")
+    timer("Debug", 100)
 }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -19,7 +19,7 @@
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
 @persist Trucks:array
-@persist Speedo:table SpeedRaw
+@outputs Debugger:table
 @strict
 
 if (first() | duped())
@@ -76,6 +76,8 @@ if (first() | duped())
         #speedometerSetSmoothing(Speedo, 0.5)
         speedometerStart(Speedo)
 
+        timer("Debug", 100)
+
     }
     catch (Exception)
     {
@@ -96,4 +98,10 @@ if (clk(speedoGetClockId(Speedo)))
 
 if (tickClk())
 {
+}
+
+if (clk("Debug"))
+{
+    stoptimer("Debug")
+    timer("Debug", 100)
 }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -153,6 +153,5 @@ if (clk("Debug"))
     timer("Debug", 100)
     Debugger["Speed Raw", number] = SpeedRaw
     Debugger["Speed Filtered", number] = SpeedFiltered
-    Debugger["Speed Final", number] = SpeedFinal
     Debugger["Speed Filter Cut-off Frequency (Hz)", number] = speedometerGetFilterCutOffFrequencyHz(Speedo)
 }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -30,6 +30,12 @@ if (first() | duped())
 
     try
     {
+        # Initialize Smart Entity Management library.
+        if(!semInit())
+        {
+            error("Failed to initialize Smart Entity Management library.")
+        }
+
         # Lock E2 so it can't be edited by other players in multiplayer mode.
         # This prevents players from accidentally breaking the E2.
         if (!semLockE2())

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -19,6 +19,7 @@
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
 @persist Trucks:array
+@persist Speedo:table SpeedRaw SpeedFiltered
 @outputs Debugger:table
 @strict
 
@@ -74,6 +75,7 @@ if (first() | duped())
         }
         #speedometerSetUnits(Speedo, "mph")
         #speedometerSetSmoothing(Speedo, 0.5)
+        speedometerSetFilterCutoffFrequency(Speedo, 10) 
         speedometerStart(Speedo)
 
         timer("Debug", 100)
@@ -86,14 +88,18 @@ if (first() | duped())
         # This also prevents the E2 from being permanently parented to the locomotive.
         semUnlockE2()
         semSmartUnparentE2fromLocoBody()
-        printColor(vec(255, 0, 0), "[RailDriver | Error]: ", vec(255, 255, 255), Exception)
+        printColor(vec(255, 0, 0), "[RailDriver | Error]", vec(255, 255, 255), ": " + Exception)
     }
 }
 
-if (clk(speedoGetClockId(Speedo)))
+if (clk(speedometerGetClockId(Speedo)))
 {
-    speedoClearAndRestartTimer(Speedo)
-    SpeedRaw = speedoGetSpeed(Speedo, 1)
+    speedometerClearAndRestartTimer(Speedo)
+    SpeedRaw = speedometerGetSpeed(Speedo, 1)
+
+    # Apply a low-pass filter to the raw speed.
+    SpeedFiltered = speedometerFilter(Speedo, SpeedRaw)
+
 }
 
 if (tickClk())
@@ -104,4 +110,8 @@ if (clk("Debug"))
 {
     stoptimer("Debug")
     timer("Debug", 100)
+    Debugger["Speed Raw", number] = SpeedRaw
+    Debugger["Speed Filtered", number] = SpeedFiltered
+    Debugger["Speed Final", number] = SpeedFinal
+    Debugger["Speed Filter Cut-off Frequency (Hz)", number] = speedometerGetFilterCutOffFrequencyHz(Speedo)
 }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -100,7 +100,7 @@ if (first() | duped())
         KeyboardControls["Decrease Engine Brake", string] = "left ctrl + A"
         KeyboardControls["Emergency Brake", string] = "space"
         KeyboardControls["Horn", string] = "H"
-        KeyboardControls["bell", string] = "left alt"
+        KeyboardControls["Bell", string] = "left alt"
         KeyboardControls["Headlights", string] = "F"
         KeyboardControls["Ditch Lights", string] = "left shift + F"
 

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -164,7 +164,9 @@ if (clk("Debug"))
 {
     stoptimer("Debug")
     timer("Debug", 100)
-    Debugger["Speed Raw", number] = SpeedRaw
-    Debugger["Speed Filtered", number] = SpeedFiltered
-    Debugger["Speed Filter Cut-off Frequency (Hz)", number] = speedometerGetFilterCutOffFrequencyHz(Speedo)
+    Debugger["Speed", number] = SpeedFiltered
+    Debugger["Reverser", number] = playerControlsGetDirection(PlayerControls)
+    Debugger["Throttle", number] = playerControlsGetThrottle(PlayerControls)
+    Debugger["Brake", number] = playerControlsGetBrake(PlayerControls)
+    Debugger["Emergency Brake", number] = playerControlsGetEmergencyBrake(PlayerControls)
 }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -30,8 +30,6 @@ if (first() | duped())
     #include "e2shared/RailDriver/lib/controls/playerControls"
     #include "e2shared/RailDriver/lib/pidf"
 
-    # I am just putting this here, to test something. I'll yeet it when I'm done.
-
     try
     {
         # Initialize Smart Entity Management library.

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -84,7 +84,6 @@ if (first() | duped())
         ThrottleMap["Velocity Setpoint", array] = array(0, 5, 15, 20, 30, 40, 60)
         ThrottleMap["Acceleration Setpoint", array] = array(0, 0.5, 1, 1.5, 2, 2.5, 3)
         BrakeMap["Brake Input Type", string] = "Velocity"
-        BrakeMap["Velocity Setpoint", array] = array(0, 5, 15, 20, 30, 40, 60)
         BrakeMap["Deceleration Setpoint", array] = array(0, -0.5, -1, -1.5, -2, -2.5, -3)
 
         # Setup default key bindings.

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -57,9 +57,10 @@ if (first() | duped())
         }
 
         # Check that the trucks are valid physics objects.
-        for (I = 1, I <= Trucks:count(), I++)
+        for (I = 1, Trucks:count())
         {
-            if (!Trucks[I, entity]:isValid() | !Trucks[I, entity]:isValidPhysics())
+            # Use an alternative version, to prevent false positives.
+            if (Trucks[I, entity] == noentity())
             {
                 error("Truck " + I + " is not a valid physics object.")
             }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -19,7 +19,7 @@
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
 @persist Trucks:array
-@persist Speedo:table SpeedRaw SpeedFiltered
+@persist [PlayerControls ThrottleMap BrakeMap]:table TrainDriver:entity SpeedFiltered
 @outputs Debugger:table
 @strict
 
@@ -27,6 +27,7 @@ if (first() | duped())
 {
     #include "e2shared/RailDriver/lib/smartEntityManagement"
     #include "e2shared/RailDriver/lib/sensors/speedometer"
+    #include "e2shared/RailDriver/lib/controls/playerControls"
     #include "e2shared/RailDriver/lib/pidf"
 
     try
@@ -78,6 +79,39 @@ if (first() | duped())
         speedometerSetFilterCutoffFrequency(Speedo, 10) 
         speedometerStart(Speedo)
 
+        # Setup throttle and brake maps.
+        ThrottleMap["Throttle Input Type", string] = "Velocity"
+        ThrottleMap["Velocity Setpoint", array] = array(0, 5, 15, 20, 30, 40, 60)
+        ThrottleMap["Acceleration Setpoint", array] = array(0, 0.5, 1, 1.5, 2, 2.5, 3)
+        BrakeMap["Brake Input Type", string] = "Velocity"
+        BrakeMap["Velocity Setpoint", array] = array(0, 5, 15, 20, 30, 40, 60)
+        BrakeMap["Deceleration Setpoint", array] = array(0, -0.5, -1, -1.5, -2, -2.5, -3)
+
+        # Setup default key bindings.
+        local KeyboardControls = table()
+        KeyboardControls["Increase Reverser", string] = "W"
+        KeyboardControls["Decrease Reverser", string] = "S"
+        KeyboardControls["Increase Throttle", string] = "D"
+        KeyboardControls["Decrease Throttle", string] = "A"
+        KeyboardControls["Increase Train Brake", string] = "left shift + D"
+        KeyboardControls["Decrease Train Brake", string] = "left shift + A"
+        KeyboardControls["Increase Engine Brake", string] = "left ctrl + D"
+        KeyboardControls["Decrease Engine Brake", string] = "left ctrl + A"
+        KeyboardControls["Emergency Brake", string] = "space"
+        KeyboardControls["Horn", string] = "H"
+        KeyboardControls["bell", string] = "left alt"
+        KeyboardControls["Headlights", string] = "F"
+        KeyboardControls["Ditch Lights", string] = "left shift + F"
+
+        # Set the driver to the player who spawned the E2.
+        TrainDriver = owner()
+
+        # Initialize and configure the player controls with keyboard controls, throttle and brake maps, and the driver.
+        PlayerControls = playerControlsInit(KeyboardControls, ThrottleMap, BrakeMap, TrainDriver)
+        if (!PlayerControls)
+        {
+            error("Failed to initialize player controls.")
+        }
         timer("Debug", 100)
 
     }
@@ -100,6 +134,12 @@ if (clk(speedometerGetClockId(Speedo)))
     # Apply a low-pass filter to the raw speed.
     SpeedFiltered = speedometerFilter(Speedo, SpeedRaw)
 
+}
+
+if (keyClk())
+{
+    # Update the player controls.
+    playerControlsUpdate(PlayerControls)
 }
 
 if (tickClk())

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -83,8 +83,10 @@ if (first() | duped())
         ThrottleMap["Throttle Input Type", string] = "Velocity"
         ThrottleMap["Velocity Setpoint", array] = array(0, 5, 15, 20, 30, 40, 60)
         ThrottleMap["Acceleration Setpoint", array] = array(0, 0.5, 1, 1.5, 2, 2.5, 3)
+        ThrottleMap["Torque Setpoint", array] = array(0, 1000, 2000, 3000, 4000, 5000, 6000)
         BrakeMap["Brake Input Type", string] = "Velocity"
         BrakeMap["Deceleration Setpoint", array] = array(0, -0.5, -1, -1.5, -2, -2.5, -3)
+        BrakeMap["Torque Setpoint", array] = array(0, -1000, -2000, -3000, -4000, -5000, -6000)
 
         # Setup default key bindings.
         local KeyboardControls = table()

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -141,6 +141,19 @@ if (keyClk())
 {
     # Update the player controls.
     playerControlsUpdate(PlayerControls)
+
+    try
+    {
+        # Check if the player controls are valid.
+        if (!playerControlsValid(PlayerControls, SpeedFiltered))
+        {
+            error(playerControlsGetFaultMessage(PlayerControls))
+        }
+    }
+    catch (Exception)
+    {
+        printColor(vec(255, 0, 0), "[RailDriver | Error]", vec(255, 255, 255), ": " + Exception)
+    }
 }
 
 if (tickClk())

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -716,7 +716,7 @@ function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, Bra
     Controls["Direction", number] = 0
     Controls["Throttle", number] = 0
     Controls["Brake", number] = 0
-    Controls["EmergencyBrake", number] = 0
+    Controls["Emergency Brake", number] = 0
     Controls["Horn", number] = 0
     Controls["Bell", number] = 0
     Controls["Headlights", number] = 0
@@ -733,7 +733,7 @@ function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, Bra
     Controls["Faults", table]["Direction", number] = 0
     Controls["Faults", table]["Throttle", number] = 0
     Controls["Faults", table]["Brake", number] = 0
-    Controls["Faults", table]["EmergencyBrake", number] = 0
+    Controls["Faults", table]["Emergency Brake", number] = 0
     Controls["Faults", table]["Message", string] = ""
 
     runOnKeys(Controls["TrainDriver", entity], 1)
@@ -809,14 +809,14 @@ function void playerControlsUpdate(Controls:table)
     # Update the emergency brake.
     elseif (EmergencyBrake)
     {
-        if (Controls["EmergencyBrake", number] == 0)
+        if (Controls["Emergency Brake", number] == 0)
         {
-            Controls["EmergencyBrake", number] = 1
+            Controls["Emergency Brake", number] = 1
         }
         else
         {
             Controls["Faults", table]["Message", string] = "Emergency brake is already applied."
-            Controls["Faults", table]["EmergencyBrake", number] = 1
+            Controls["Faults", table]["Emergency Brake", number] = 1
         }
     }
 }
@@ -842,7 +842,7 @@ function number playerControlsGetBrake(Controls:table)
 # This function returns the emergency brake of the locomotive.
 function number playerControlsGetEmergencyBrake(Controls:table)
 {
-    return Controls["EmergencyBrake", number]
+    return Controls["Emergency Brake", number]
 }
 
 # This function returns the horn of the locomotive.
@@ -876,7 +876,7 @@ function number playerControlsValid(Controls:table, Speed)
     local Direction = Controls["Direction", number]
     local Throttle = Controls["Throttle", number]
     local Brake = Controls["Brake", number]
-    local EmergencyBrake = Controls["EmergencyBrake", number]
+    local EmergencyBrake = Controls["Emergency Brake", number]
 
     # Get the throttle & brake maps.
     local ThrMap = Controls["ThrottleMap", table]

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -198,37 +198,37 @@ function void playerControlsUpdate(Controls:table)
             }
 
             # Set emergency brake if the emergency brake key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][5, string])
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][7, string])
             {
                 Controls["EmergencyBrake", number] = 1
             }
 
             # Set horn if the horn key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][6, string])
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][8, string])
             {
                 Controls["Horn", number] = 1
             }
 
             # Release horn if the horn key is released.
-            elseif (KeyState == -1 & KeyPressed == Controls["Controls", array][6, string])
+            if (KeyState == 0 & KeyPressed == Controls["Controls", array][8, string])
             {
                 Controls["Horn", number] = 0
             }
 
             # Toggle bell if the bell key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][7, string])
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][9, string])
             {
                 Controls["Bell", number] = Controls["Bell", number] == 0 ? 1 : 0
             }
 
             # Toggle headlights if the headlights key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][8, string])
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][10, string])
             {
                 Controls["Headlights", number] = Controls["Headlights", number] == 0 ? 1 : 0
             }
 
             # Toggle ditch lights if the ditch lights key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][9, string])
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][11, string])
             {
                 Controls["DitchLights", number] = Controls["DitchLights", number] == 0 ? 1 : 0
             }

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -720,7 +720,7 @@ function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, Bra
     Controls["Horn", number] = 0
     Controls["Bell", number] = 0
     Controls["Headlights", number] = 0
-    Controls["DitchLights", number] = 0
+    Controls["Ditch Lights", number] = 0
     Controls["TrainDriver", entity] = TrainDriver
     Controls["Controls", table] = encodeKeyboardControls(KeyboardControls)
 
@@ -866,7 +866,7 @@ function number playerControlsGetHeadlights(Controls:table)
 # This function returns the ditch lights of the locomotive.
 function number playerControlsGetDitchLights(Controls:table)
 {
-    return Controls["DitchLights", number]
+    return Controls["Ditch Lights", number]
 }
 
 # This function checks whether or not the player controls are valid.

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -35,9 +35,12 @@ function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, Bra
     Controls["Headlights", number] = 0
     Controls["DitchLights", number] = 0
     Controls["TrainDriver", entity] = TrainDriver
-    Controls["Controls", array] = KeyboardControls:toArray()
-    Controls["ThrottleMap", array] = ThrottleMap:toArray()
-    Controls["BrakeMap", array] = BrakeMap:toArray()
+    Controls["Controls", table] = KeyboardControls
+
+    # 'table:toArray()' is bugged, so I am directly using the throttle and brake maps.
+    Controls["ThrottleMap", table] = ThrottleMap
+    Controls["BrakeMap", table] = BrakeMap
+
     runOnKeys(Controls["TrainDriver", entity], 1)
     return Controls
 }

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -152,3 +152,25 @@ function number playerControlsGetThrottle(Controls:table, PIDFMode:number)
     }
 }
 
+# This function returns the player's brake input based on the brake map & what operating mode the PIDF controller is in.
+function number playerControlsGetBrake(Controls:table, PIDFMode:number)
+{
+    # Brake is always 0 if the PIDF controller is in velocity mode.
+    if (PIDFMode == 0)
+    {
+        return 0
+    }
+
+    # If the PIDF controller is in acceleration mode, return the brake map value.
+    elseif (PIDFMode == 1)
+    {
+        return Controls["BrakeMap", array][Controls["Brake", number], number]
+    }
+
+    # If the PIDF controller is in torque mode, return the brake value.
+    elseif (PIDFMode == 2)
+    {
+        return Controls["Brake", number]
+    }
+}
+

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -42,6 +42,14 @@ function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, Bra
     Controls["ThrottleMap", table] = ThrottleMap
     Controls["BrakeMap", table] = BrakeMap
 
+    # Fault Reporting for the player controls.
+    Controls["Faults", table] = table()
+    Controls["Faults", table]["Direction", number] = 0
+    Controls["Faults", table]["Throttle", number] = 0
+    Controls["Faults", table]["Brake", number] = 0
+    Controls["Faults", table]["EmergencyBrake", number] = 0
+    Controls["Faults", table]["Message", string] = ""
+
     runOnKeys(Controls["TrainDriver", entity], 1)
     return Controls
 }
@@ -282,4 +290,277 @@ function number playerControlsGetHeadlights(Controls:table)
 function number playerControlsGetDitchLights(Controls:table)
 {
     return Controls["DitchLights", number]
+}
+
+# This function checks whether or not the player controls are valid.
+function number playerControlsValid(Controls:table, Speed)
+{
+    # Get the direction, throttle, brake, and emergency brake.
+    local Direction = Controls["Direction", number]
+    local Throttle = Controls["Throttle", number]
+    local Brake = Controls["Brake", number]
+    local EmergencyBrake = Controls["EmergencyBrake", number]
+
+    # Get the throttle & brake maps.
+    local ThrMap = Controls["ThrottleMap", table]
+    local BrkMap = Controls["BrakeMap", table]
+
+    # Get the throttle & brake input types.
+    local ThrInputType = ThrMap["Throttle Input Type", string]
+    local BrkInputType = BrkMap["Brake Input Type", string]
+
+    # Direction cannot be set higher than 1 or lower than -1.
+    if (Direction > 1)
+    {
+        Controls["Direction", number] = 1
+        Controls["Faults", table]["Message", string] = "Direction is already set to forward."
+        Controls["Faults", table]["Direction", number] = 1
+        return 0
+    }
+
+    elseif (Direction < -1)
+    {
+        Controls["Direction", number] = -1
+        Controls["Faults", table]["Message", string] = "Direction is already set to reverse."
+        Controls["Faults", table]["Direction", number] = 1
+        return 0
+    }
+
+    # Direction must remain set to forward when the locomotive is moving forward,
+    # and direction must remain set to reverse when the locomotive is moving in reverse.
+    if (Direction != 1 & Speed > 0)
+    {
+        Controls["Direction", number] = 1
+        Controls["Faults", table]["Message", string] = "Cannot set direction whilst the locomotive is moving."
+        Controls["Faults", table]["Direction", number] = 1
+        return 0
+    }
+
+    elseif (Direction != -1 & Speed > 0)
+    {
+        Controls["Direction", number] = -1
+        Controls["Faults", table]["Message", string] = "Cannot set direction whilst the locomotive is moving."
+        Controls["Faults", table]["Direction", number] = 1
+        return 0
+    }
+
+    # Throttle is invalid when the locomotive's direction is neutral.
+    if (Throttle > 0 & Direction == 0)
+    {
+        Controls["Throttle", number] = 0
+        Controls["Faults", table]["Message", string] = "Throttle is invalid when the locomotive's direction is neutral."
+        Controls["Faults", table]["Throttle", number] = 1
+        return 0
+    }
+
+    # Throttle is invalid when its value is higher than or less than the size of the throttle maps for each throttle input type.
+    switch(ThrInputType)
+    {
+        # Velocity Mode.
+        case "Velocity",
+            # Throttle cannot be set higher than the maximum size of the Throttle Map.
+            if (Throttle > ThrMap["Velocity Setpoint", array]:count())
+            {
+                Controls["Throttle", number] = ThrMap["Velocity Setpoint", array]:count()
+                Controls["Faults", table]["Message", string] = "Throttle is already set to maximum."
+                Controls["Faults", table]["Throttle", number] = 1
+                return 0
+            }
+
+            # Throttle cannot be set lower than 0.
+            elseif (Throttle < 0)
+            {
+                Controls["Throttle", number] = 0
+                Controls["Faults", table]["Message", string] = "Throttle is already set to minimum."
+                Controls["Faults", table]["Throttle", number] = 1
+                return 0
+            }
+        break
+
+        # Acceleration Mode.
+        case "Acceleration",
+            # Throttle cannot be set higher than the maximum size of the Throttle Map.
+            if (Throttle > ThrMap["Acceleration Setpoint", array]:count())
+            {
+                Controls["Throttle", number] = ThrMap["Acceleration Setpoint", array]:count()
+                Controls["Faults", table]["Message", string] = "Throttle is already set to maximum."
+                Controls["Faults", table]["Throttle", number] = 1
+                return 0
+            }
+
+            # Throttle cannot be set lower than 0.
+            elseif (Throttle < 0)
+            {
+                Controls["Throttle", number] = 0
+                Controls["Faults", table]["Message", string] = "Throttle is already set to minimum."
+                Controls["Faults", table]["Throttle", number] = 1
+                return 0
+            }
+        break
+
+        # Torque Mode.
+        case "Torque",
+            # Throttle cannot be set higher than the maximum size of the Throttle Map.
+            if (Throttle > ThrMap["Torque Setpoint", array]:count())
+            {
+                Controls["Throttle", number] = ThrMap["Torque Setpoint", array]:count()
+                Controls["Faults", table]["Message", string] = "Throttle is already set to maximum."
+                Controls["Faults", table]["Throttle", number] = 1
+                return 0
+            }
+
+            # Throttle cannot be set lower than 0.
+            elseif (Throttle < 0)
+            {
+                Controls["Throttle", number] = 0
+                Controls["Faults", table]["Message", string] = "Throttle is already set to minimum."
+                Controls["Faults", table]["Throttle", number] = 1
+                return 0
+            }
+        break
+    }
+
+    # Brake is invalid when its value is higher than or less than the size of the brake maps for each brake input type.
+    switch(BrkInputType)
+    {
+        # Velocity Mode.
+        case "Velocity",
+            # Brake is disabled in Velocity Mode. Any value set to the brake is invalid.
+            if (Brake > 0)
+            {
+                Controls["Brake", number] = 0
+                Controls["Faults", table]["Message", string] = "Brake is disabled in Velocity Mode."
+                Controls["Faults", table]["Brake", number] = 1
+                return 0
+            }
+        break
+
+        # Acceleration Mode.
+        case "Acceleration",
+            # Brake cannot be set higher than the maximum size of the Brake Map.
+            if (Brake > BrkMap["Acceleration Setpoint", array]:count())
+            {
+                Controls["Brake", number] = BrkMap["Deceleration Setpoint", array]:count()
+                Controls["Faults", table]["Message", string] = "Brake is already set to maximum."
+                Controls["Faults", table]["Brake", number] = 1
+                return 0
+            }
+
+            # Brake cannot be set lower than 0.
+            elseif (Brake < 0)
+            {
+                Controls["Brake", number] = 0
+                Controls["Faults", table]["Message", string] = "Brake is already set to minimum."
+                Controls["Faults", table]["Brake", number] = 1
+                return 0
+            }
+        break
+
+        # Torque Mode.
+        case "Torque",
+            # Brake cannot be set higher than the maximum size of the Brake Map.
+            if (Brake > BrkMap["Torque Setpoint", array]:count())
+            {
+                Controls["Brake", number] = BrkMap["Torque Setpoint", array]:count()
+                Controls["Faults", table]["Message", string] = "Brake is already set to maximum."
+                Controls["Faults", table]["Brake", number] = 1
+                return 0
+            }
+        break
+    }
+
+    # Return 1 if all checks have passed.
+    return 1
+}
+
+# This function returns the fault message.
+function string playerControlsGetFaultMessage(Controls:table)
+{
+    return Controls["Faults", table]["Message", string]
+}
+
+# This function returns the direction fault.
+function number playerControlsGetDirectionFault(Controls:table)
+{
+    return Controls["Faults", table]["Direction", number]
+}
+
+# This function returns the throttle fault.
+function number playerControlsGetThrottleFault(Controls:table)
+{
+    return Controls["Faults", table]["Throttle", number]
+}
+
+# This function returns the brake fault.
+function number playerControlsGetBrakeFault(Controls:table)
+{
+    return Controls["Faults", table]["Brake", number]
+}
+
+# This function clears the fault message.
+# Returns true if the fault message was cleared.
+# False if no fault message was found.
+function number playerControlsClearFaultMessage(Controls:table)
+{
+    if (Controls["Faults", table]["Message", string] != "")
+    {
+        Controls["Faults", table]["Message", string] = ""
+        return 1
+    }
+    else
+    {
+        Controls["Faults", table]["Message", string] = "No fault message found."
+        return 0
+    }
+}
+
+# This function clears the direction fault.
+# Returns true if the direction fault was cleared.
+# False if the direction fault was not previously set.
+function number playerControlsClearDirectionFault(Controls:table)
+{
+    if (Controls["Faults", table]["Direction", number] == 1)
+    {
+        Controls["Faults", table]["Direction", number] = 0
+        return 1
+    }
+    else
+    {
+        Controls["Faults", table]["Message", string] = "Direction fault was not previously set."
+        return 0
+    }
+}
+
+# This function clears the throttle fault.
+# Returns true if the throttle fault was cleared.
+# False if the throttle fault was not previously set.
+function number playerControlsClearThrottleFault(Controls:table)
+{
+    if (Controls["Faults", table]["Throttle", number] == 1)
+    {
+        Controls["Faults", table]["Throttle", number] = 0
+        return 1
+    }
+    else
+    {
+        Controls["Faults", table]["Message", string] = "Throttle fault was not previously set."
+        return 0
+    }
+}
+
+# This function clears the brake fault.
+# Returns true if the brake fault was cleared.
+# False if the brake fault was not previously set.
+function number playerControlsClearBrakeFault(Controls:table)
+{
+    if (Controls["Faults", table]["Brake", number] == 1)
+    {
+        Controls["Faults", table]["Brake", number] = 0
+        return 1
+    }
+    else
+    {
+        Controls["Faults", table]["Message", string] = "Brake fault was not previously set."
+        return 0
+    }
 }

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -42,3 +42,85 @@ function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, Bra
     return Controls
 }
 
+# This function updates the player controls.
+# This function should be called every key clock tick.
+function void playerControlsUpdate(Controls:table)
+{
+    local KeyPressed = keyClkPressed()
+    local KeyState = keyClk(Controls["TrainDriver", entity]) == 1 ? 1 : 0
+
+    local String = ""
+    String += "Key: " + KeyPressed + ", State: " + KeyState
+    #printColor(vec(0, 255, 0), "[RailDriver | DEBUG]", vec(255, 255, 255), ": " + String)
+
+    if (Controls["TrainDriver", entity]:inVehicle())
+    {
+        if (KeyPressed)
+        {
+            # Set direction to forward if the forward key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][1, string])
+            {
+                Controls["Direction", number] = Controls["Direction", number] + 1
+                Controls["Direction", number] = clamp(Controls["Direction", number], -1, 1)
+            }
+
+            # Set direction to reverse if the reverse key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][2, string])
+            {
+                Controls["Direction", number] = Controls["Direction", number] - 1
+                Controls["Direction", number] = clamp(Controls["Direction", number], -1, 1)
+            }
+
+            # Increase throttle if the increase throttle key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][3, string])
+            {
+                Controls["Throttle", number] = Controls["Throttle", number] + 1
+                Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, Controls["ThrottleMap", array]:count())
+            }
+
+            # Decrease throttle if the decrease throttle key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][4, string])
+            {
+                Controls["Throttle", number] = Controls["Throttle", number] - 1
+                Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, Controls["ThrottleMap", array]:count())
+            }
+
+            # Set emergency brake if the emergency brake key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][5, string])
+            {
+                Controls["Brake", number] = -1
+            }
+
+            # Set horn if the horn key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][6, string])
+            {
+                Controls["Horn", number] = 1
+            }
+
+            # Release horn if the horn key is released.
+            elseif (KeyState == -1 & KeyPressed == Controls["Controls", array][6, string])
+            {
+                Controls["Horn", number] = 0
+            }
+
+            # Toggle bell if the bell key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][7, string])
+            {
+                Controls["Bell", number] = Controls["Bell", number] == 0 ? 1 : 0
+            }
+
+            # Toggle headlights if the headlights key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][8, string])
+            {
+                Controls["Headlights", number] = Controls["Headlights", number] == 0 ? 1 : 0
+            }
+
+            # Toggle ditch lights if the ditch lights key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][9, string])
+            {
+                Controls["DitchLights", number] = Controls["DitchLights", number] == 0 ? 1 : 0
+            }
+        }
+    }
+}
+

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -30,6 +30,7 @@ function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, Bra
     Controls["Direction", number] = 0
     Controls["Throttle", number] = 0
     Controls["Brake", number] = 0
+    Controls["EmergencyBrake", number] = 0
     Controls["Horn", number] = 0
     Controls["Bell", number] = 0
     Controls["Headlights", number] = 0
@@ -199,7 +200,7 @@ function void playerControlsUpdate(Controls:table)
             # Set emergency brake if the emergency brake key is pressed.
             if (KeyState == 1 & KeyPressed == Controls["Controls", array][5, string])
             {
-                Controls["Brake", number] = -1
+                Controls["EmergencyBrake", number] = 1
             }
 
             # Set horn if the horn key is pressed.

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -932,7 +932,7 @@ function number playerControlsValid(Controls:table, Speed)
     }
 
     # Throttle is invalid when the locomotive's direction is neutral.
-    if (Throttle > 0 & Direction == 0)
+    if (Throttle != 0 & Direction == 0)
     {
         Controls["Throttle", number] = 0
         Controls["Faults", table]["Message", string] = "Throttle is invalid when the locomotive's direction is neutral."

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -77,15 +77,63 @@ function void playerControlsUpdate(Controls:table)
             # Increase throttle if the increase throttle key is pressed.
             if (KeyState == 1 & KeyPressed == Controls["Controls", array][3, string])
             {
+                # Increase throttle by 1.
                 Controls["Throttle", number] = Controls["Throttle", number] + 1
-                Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, Controls["ThrottleMap", array]:count())
+
+                # Get the throttle map.
+                local ThrMap = Controls["ThrottleMap", table]
+
+                # Clamp the throttle to the maximum value in the throttle map.
+                # Each throttle map has its own minimum & maximum values.
+                switch(ThrMap["Throttle Input Type", string])
+                {
+                    # Velocity Mode.
+                    case "Velocity",
+                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Velocity Setpoint", array]:count())
+                    break
+
+                    # Acceleration Mode.
+                    case "Acceleration",
+                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Acceleration Setpoint", array]:count())
+                    break
+
+                    # Torque Mode.
+                    case "Torque",
+                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Torque Setpoint", array]:count())
+                    break
+                }
             }
 
             # Decrease throttle if the decrease throttle key is pressed.
             if (KeyState == 1 & KeyPressed == Controls["Controls", array][4, string])
             {
+                # Decrease throttle by 1.
                 Controls["Throttle", number] = Controls["Throttle", number] - 1
-                Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, Controls["ThrottleMap", array]:count())
+
+                # Get the throttle map.
+                local ThrMap = Controls["ThrottleMap", table]
+
+                # Clamp the throttle to the minimum value in the throttle map.
+                # Each throttle map has its own minimum & maximum values.
+                switch(ThrMap["Throttle Input Type", string])
+                {
+                    # Velocity Mode.
+                    case "Velocity",
+                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Velocity Setpoint", array]:count())
+                    break
+
+                    # Acceleration Mode.
+                    case "Acceleration",
+                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Acceleration Setpoint", array]:count())
+                    break
+
+                    # Torque Mode.
+                    case "Torque",
+                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Torque Setpoint", array]:count())
+                    break
+                }
+            }
+
             }
 
             # Set emergency brake if the emergency brake key is pressed.

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -652,187 +652,180 @@ function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, Bra
 # This function should be called every key clock tick.
 function void playerControlsUpdate(Controls:table)
 {
-    local KeyPressed = keyClkPressed()
-    local KeyState = keyClk(Controls["TrainDriver", entity]) == 1 ? 1 : 0
+    local KeyboardControls = Controls["Controls", table]
+    local Driver = Controls["TrainDriver", entity]
 
-    local String = ""
-    String += "Key: " + KeyPressed + ", State: " + KeyState
-    #printColor(vec(0, 255, 0), "[RailDriver | DEBUG]", vec(255, 255, 255), ": " + String)
-
-    if (Controls["TrainDriver", entity]:inVehicle())
+    # Set the locomotive's direction.
+    # Here, the direction selector is no longer clamped.
+    # This is to allow the fault reporting system to alert the player when the direction selector is out of range.
+    if (KeyboardControls["Increase Direction Modifier", string] != "" & KeyboardControls["Increase Direction Key", string] != "")
     {
-        if (KeyPressed)
+        if (Driver:keyPressed(KeyboardControls["Increase Direction Modifier", string]) & Driver:keyPressed(KeyboardControls["Increase Direction Key", string]))
         {
-            # Set direction to forward if the forward key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][1, string])
+            Controls["Direction", number] = Controls["Direction", number] + 1
+        }
+    }
+
+    elseif (KeyboardControls["Increase Direction Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Increase Direction Key", string]))
+        {
+            Controls["Direction", number] = Controls["Direction", number] + 1
+        }
+    }
+
+    if (KeyboardControls["Decrease Direction Modifier", string] != "" & KeyboardControls["Decrease Direction Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Decrease Direction Modifier", string]) & Driver:keyPressed(KeyboardControls["Decrease Direction Key", string]))
+        {
+            Controls["Direction", number] = Controls["Direction", number] - 1
+        }
+    }
+
+    elseif (KeyboardControls["Decrease Direction Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Decrease Direction Key", string]))
+        {
+            Controls["Direction", number] = Controls["Direction", number] - 1
+        }
+    }
+
+    # Set the locomotive's throttle.
+    # Here, the throttle selector is no longer clamped.
+    # This is to allow the fault reporting system to alert the player when the throttle selector is out of range.
+    if (KeyboardControls["Increase Throttle Modifier", string] != "" & KeyboardControls["Increase Throttle Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Increase Throttle Modifier", string]) & Driver:keyPressed(KeyboardControls["Increase Throttle Key", string]))
+        {
+            Controls["Throttle", number] = Controls["Throttle", number] + 1
+        }
+    }
+
+    elseif (KeyboardControls["Increase Throttle Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Increase Throttle Key", string]))
+        {
+            Controls["Throttle", number] = Controls["Throttle", number] + 1
+        }
+    }
+
+    if (KeyboardControls["Decrease Throttle Modifier", string] != "" & KeyboardControls["Decrease Throttle Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Decrease Throttle Modifier", string]) & Driver:keyPressed(KeyboardControls["Decrease Throttle Key", string]))
+        {
+            Controls["Throttle", number] = Controls["Throttle", number] - 1
+        }
+    }
+
+    elseif (KeyboardControls["Decrease Throttle Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Decrease Throttle Key", string]))
+        {
+            Controls["Throttle", number] = Controls["Throttle", number] - 1
+        }
+    }
+
+    # Set the train brake.
+    # Here, the brake selector is no longer clamped.
+    # This is to allow the fault reporting system to alert the player when the train brake selector is out of range.
+    if (KeyboardControls["Increase Train Brake Modifier", string] != "" & KeyboardControls["Increase Train Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Increase Train Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Increase Train Brake Key", string]))
+        {
+            Controls["Brake", number] = Controls["Brake", number] + 1
+        }
+    }
+
+    elseif (KeyboardControls["Increase Train Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Increase Train Brake Key", string]))
+        {
+            Controls["Brake", number] = Controls["Brake", number] + 1
+        }
+    }
+
+    if (KeyboardControls["Decrease Train Brake Modifier", string] != "" & KeyboardControls["Decrease Train Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Decrease Train Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Decrease Train Brake Key", string]))
+        {
+            Controls["Brake", number] = Controls["Brake", number] - 1
+        }
+    }
+
+    elseif (KeyboardControls["Decrease Train Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Decrease Train Brake Key", string]))
+        {
+            Controls["Brake", number] = Controls["Brake", number] - 1
+        }
+    }
+
+    # Set the engine brake.
+    # Here, the engine brake selector is no longer clamped.
+    # This is to allow the fault reporting system to alert the player when the engine brake selector is out of range.
+    if (KeyboardControls["Increase Engine Brake Modifier", string] != "" & KeyboardControls["Increase Engine Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Increase Engine Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Increase Engine Brake Key", string]))
+        {
+            Controls["Brake", number] = Controls["Brake", number] + 1
+        }
+    }
+
+    elseif (KeyboardControls["Increase Engine Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Increase Engine Brake Key", string]))
+        {
+            Controls["Brake", number] = Controls["Brake", number] + 1
+        }
+    }
+
+    if (KeyboardControls["Decrease Engine Brake Modifier", string] != "" & KeyboardControls["Decrease Engine Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Decrease Engine Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Decrease Engine Brake Key", string]))
+        {
+            Controls["Brake", number] = Controls["Brake", number] - 1
+        }
+    }
+
+    elseif (KeyboardControls["Decrease Engine Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Decrease Engine Brake Key", string]))
+        {
+            Controls["Brake", number] = Controls["Brake", number] - 1
+        }
+    }
+
+    # Set the emergency brake.
+    if (KeyboardControls["Emergency Brake Modifier", string] != "" & KeyboardControls["Emergency Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Emergency Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Emergency Brake Key", string]))
+        {
+            if (Controls["Emergency Brake", number] == 0)
             {
-                Controls["Direction", number] = Controls["Direction", number] + 1
-                Controls["Direction", number] = clamp(Controls["Direction", number], -1, 1)
+                Controls["Emergency Brake", number] = 1
             }
 
-            # Set direction to reverse if the reverse key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][2, string])
+            else
             {
-                Controls["Direction", number] = Controls["Direction", number] - 1
-                Controls["Direction", number] = clamp(Controls["Direction", number], -1, 1)
+                Controls["Faults", table]["Message", string] = "Emergency brake is already applied."
+                Controls["Faults", table]["EmergencyBrake", number] = 1
+            }
+        }
+    }
+
+    elseif (KeyboardControls["Emergency Brake Key", string] != "")
+    {
+        if (Driver:keyPressed(KeyboardControls["Emergency Brake Key", string]))
+        {
+            if (Controls["Emergency Brake", number] == 0)
+            {
+                Controls["Emergency Brake", number] = 1
             }
 
-            # Increase throttle if the increase throttle key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][3, string])
+            else
             {
-                # Increase throttle by 1.
-                Controls["Throttle", number] = Controls["Throttle", number] + 1
-
-                # Get the throttle map.
-                local ThrMap = Controls["ThrottleMap", table]
-
-                # Clamp the throttle to the maximum value in the throttle map.
-                # Each throttle map has its own minimum & maximum values.
-                switch(ThrMap["Throttle Input Type", string])
-                {
-                    # Velocity Mode.
-                    case "Velocity",
-                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Velocity Setpoint", array]:count())
-                    break
-
-                    # Acceleration Mode.
-                    case "Acceleration",
-                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Acceleration Setpoint", array]:count())
-                    break
-
-                    # Torque Mode.
-                    case "Torque",
-                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Torque Setpoint", array]:count())
-                    break
-                }
-            }
-
-            # Decrease throttle if the decrease throttle key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][4, string])
-            {
-                # Decrease throttle by 1.
-                Controls["Throttle", number] = Controls["Throttle", number] - 1
-
-                # Get the throttle map.
-                local ThrMap = Controls["ThrottleMap", table]
-
-                # Clamp the throttle to the minimum value in the throttle map.
-                # Each throttle map has its own minimum & maximum values.
-                switch(ThrMap["Throttle Input Type", string])
-                {
-                    # Velocity Mode.
-                    case "Velocity",
-                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Velocity Setpoint", array]:count())
-                    break
-
-                    # Acceleration Mode.
-                    case "Acceleration",
-                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Acceleration Setpoint", array]:count())
-                    break
-
-                    # Torque Mode.
-                    case "Torque",
-                        Controls["Throttle", number] = clamp(Controls["Throttle", number], 0, ThrMap["Torque Setpoint", array]:count())
-                    break
-                }
-            }
-
-            # Increase brake if the increase brake key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][5, string])
-            {
-                # Increase brake by 1.
-                Controls["Brake", number] = Controls["Brake", number] + 1
-
-                # Get the brake map.
-                local BrkMap = Controls["BrakeMap", table]
-
-                # Clamp the brake to the maximum value in the brake map.
-                # Each brake map has its own minimum & maximum values.
-                switch(BrkMap["Brake Input Type", string])
-                {
-                    # Velocity Mode.
-                    case "Velocity",
-                        # Brake is disabled in this mode.
-                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, 0)
-                    break
-
-                    # Acceleration Mode.
-                    case "Acceleration",
-                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, BrkMap["Deceleration Setpoint", array]:count())
-                    break
-
-                    # Torque Mode.
-                    case "Torque",
-                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, BrkMap["Torque Setpoint", array]:count())
-                    break
-                }
-            }
-
-            # Decrease brake if the decrease brake key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][6, string])
-            {
-                # Decrease brake by 1.
-                Controls["Brake", number] = Controls["Brake", number] - 1
-
-                # Get the brake map.
-                local BrkMap = Controls["BrakeMap", table]
-
-                # Clamp the brake to the minimum value in the brake map.
-                # Each brake map has its own minimum & maximum values.
-                switch(BrkMap["Brake Input Type", string])
-                {
-                    # Velocity Mode.
-                    case "Velocity",
-                        # Brake is disabled in this mode.
-                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, 0)
-                    break
-
-                    # Acceleration Mode.
-                    case "Acceleration",
-                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, BrkMap["Deceleration Setpoint", array]:count())
-                    break
-
-                    # Torque Mode.
-                    case "Torque",
-                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, BrkMap["Torque Setpoint", array]:count())
-                    break
-                }
-            }
-
-            # Set emergency brake if the emergency brake key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][7, string])
-            {
-                Controls["EmergencyBrake", number] = 1
-            }
-
-            # Set horn if the horn key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][8, string])
-            {
-                Controls["Horn", number] = 1
-            }
-
-            # Release horn if the horn key is released.
-            if (KeyState == 0 & KeyPressed == Controls["Controls", array][8, string])
-            {
-                Controls["Horn", number] = 0
-            }
-
-            # Toggle bell if the bell key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][9, string])
-            {
-                Controls["Bell", number] = Controls["Bell", number] == 0 ? 1 : 0
-            }
-
-            # Toggle headlights if the headlights key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][10, string])
-            {
-                Controls["Headlights", number] = Controls["Headlights", number] == 0 ? 1 : 0
-            }
-
-            # Toggle ditch lights if the ditch lights key is pressed.
-            if (KeyState == 1 & KeyPressed == Controls["Controls", array][11, string])
-            {
-                Controls["DitchLights", number] = Controls["DitchLights", number] == 0 ? 1 : 0
+                Controls["Faults", table]["Message", string] = "Emergency brake is already applied."
+                Controls["Faults", table]["EmergencyBrake", number] = 1
             }
         }
     }

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -34,42 +34,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Increase Direction Modifier", string] = "lshift"
                 ControlTable["Increase Direction Key", string] = V:sub(13):trim():upper()
+                ControlTable["Increase Direction has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Increase Direction Modifier", string] = "rshift"
                 ControlTable["Increase Direction Key", string] = V:sub(14):trim():upper()
+                ControlTable["Increase Direction has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Increase Direction Modifier", string] = "lcontrol"
                 ControlTable["Increase Direction Key", string] = V:sub(12):trim():upper()
+                ControlTable["Increase Direction has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Increase Direction Modifier", string] = "rcontrol"
                 ControlTable["Increase Direction Key", string] = V:sub(13):trim():upper()
+                ControlTable["Increase Direction has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Increase Direction Modifier", string] = "lalt"
                 ControlTable["Increase Direction Key", string] = V:sub(11):trim():upper()
+                ControlTable["Increase Direction has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Increase Direction Modifier", string] = "ralt"
                 ControlTable["Increase Direction Key", string] = V:sub(12):trim():upper()
+                ControlTable["Increase Direction has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Increase Direction Modifier", string] = ""
                 ControlTable["Increase Direction Key", string] = V:trim():upper()
+                ControlTable["Increase Direction has Modifier", number] = 0
             }
         }
 
@@ -79,42 +86,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Decrease Direction Modifier", string] = "lshift"
                 ControlTable["Decrease Direction Key", string] = V:sub(13):trim():upper()
+                ControlTable["Decrease Direction has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Decrease Direction Modifier", string] = "rshift"
                 ControlTable["Decrease Direction Key", string] = V:sub(14):trim():upper()
+                ControlTable["Decrease Direction has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Decrease Direction Modifier", string] = "lcontrol"
                 ControlTable["Decrease Direction Key", string] = V:sub(12):trim():upper()
+                ControlTable["Decrease Direction has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Decrease Direction Modifier", string] = "rcontrol"
                 ControlTable["Decrease Direction Key", string] = V:sub(13):trim():upper()
+                ControlTable["Decrease Direction has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Decrease Direction Modifier", string] = "lalt"
                 ControlTable["Decrease Direction Key", string] = V:sub(11):trim():upper()
+                ControlTable["Decrease Direction has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Decrease Direction Modifier", string] = "ralt"
                 ControlTable["Decrease Direction Key", string] = V:sub(12):trim():upper()
+                ControlTable["Decrease Direction has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Decrease Direction Modifier", string] = ""
                 ControlTable["Decrease Direction Key", string] = V:trim():upper()
+                ControlTable["Decrease Direction has Modifier", number] = 0
             }
         }
 
@@ -124,42 +138,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Increase Throttle Modifier", string] = "lshift"
                 ControlTable["Increase Throttle Key", string] = V:sub(13):trim():upper()
+                ControlTable["Increase Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Increase Throttle Modifier", string] = "rshift"
                 ControlTable["Increase Throttle Key", string] = V:sub(14):trim():upper()
+                ControlTable["Increase Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Increase Throttle Modifier", string] = "lcontrol"
                 ControlTable["Increase Throttle Key", string] = V:sub(12):trim():upper()
+                ControlTable["Increase Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Increase Throttle Modifier", string] = "rcontrol"
                 ControlTable["Increase Throttle Key", string] = V:sub(13):trim():upper()
+                ControlTable["Increase Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Increase Throttle Modifier", string] = "lalt"
                 ControlTable["Increase Throttle Key", string] = V:sub(11):trim():upper()
+                ControlTable["Increase Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Increase Throttle Modifier", string] = "ralt"
                 ControlTable["Increase Throttle Key", string] = V:sub(12):trim():upper()
+                ControlTable["Increase Throttle has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Increase Throttle Modifier", string] = ""
                 ControlTable["Increase Throttle Key", string] = V:trim():upper()
+                ControlTable["Increase Throttle has Modifier", number] = 0
             }
         }
 
@@ -169,42 +190,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Decrease Throttle Modifier", string] = "lshift"
                 ControlTable["Decrease Throttle Key", string] = V:sub(13):trim():upper()
+                ControlTable["Decrease Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Decrease Throttle Modifier", string] = "rshift"
                 ControlTable["Decrease Throttle Key", string] = V:sub(14):trim():upper()
+                ControlTable["Decrease Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Decrease Throttle Modifier", string] = "lcontrol"
                 ControlTable["Decrease Throttle Key", string] = V:sub(12):trim():upper()
+                ControlTable["Decrease Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Decrease Throttle Modifier", string] = "rcontrol"
                 ControlTable["Decrease Throttle Key", string] = V:sub(13):trim():upper()
+                ControlTable["Decrease Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Decrease Throttle Modifier", string] = "lalt"
                 ControlTable["Decrease Throttle Key", string] = V:sub(11):trim():upper()
+                ControlTable["Decrease Throttle has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Decrease Throttle Modifier", string] = "ralt"
                 ControlTable["Decrease Throttle Key", string] = V:sub(12):trim():upper()
+                ControlTable["Decrease Throttle has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Decrease Throttle Modifier", string] = ""
                 ControlTable["Decrease Throttle Key", string] = V:trim():upper()
+                ControlTable["Decrease Throttle has Modifier", number] = 0
             }
         }
 
@@ -214,42 +242,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Increase Train Brake Modifier", string] = "lshift"
                 ControlTable["Increase Train Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Increase Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Increase Train Brake Modifier", string] = "rshift"
                 ControlTable["Increase Train Brake Key", string] = V:sub(14):trim():upper()
+                ControlTable["Increase Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Increase Train Brake Modifier", string] = "lcontrol"
                 ControlTable["Increase Train Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Increase Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Increase Train Brake Modifier", string] = "rcontrol"
                 ControlTable["Increase Train Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Increase Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Increase Train Brake Modifier", string] = "lalt"
                 ControlTable["Increase Train Brake Key", string] = V:sub(11):trim():upper()
+                ControlTable["Increase Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Increase Train Brake Modifier", string] = "ralt"
                 ControlTable["Increase Train Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Increase Train Brake has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Increase Train Brake Modifier", string] = ""
                 ControlTable["Increase Train Brake Key", string] = V:trim():upper()
+                ControlTable["Increase Train Brake has Modifier", number] = 0
             }
         }
 
@@ -259,42 +294,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "lshift"
                 ControlTable["Decrease Train Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Decrease Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "rshift"
                 ControlTable["Decrease Train Brake Key", string] = V:sub(14):trim():upper()
+                ControlTable["Decrease Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "lcontrol"
                 ControlTable["Decrease Train Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Decrease Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "rcontrol"
                 ControlTable["Decrease Train Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Decrease Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "lalt"
                 ControlTable["Decrease Train Brake Key", string] = V:sub(11):trim():upper()
+                ControlTable["Decrease Train Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "ralt"
                 ControlTable["Decrease Train Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Decrease Train Brake has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Decrease Train Brake Modifier", string] = ""
                 ControlTable["Decrease Train Brake Key", string] = V:trim():upper()
+                ControlTable["Decrease Train Brake has Modifier", number] = 0
             }
         }
 
@@ -304,42 +346,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "lshift"
                 ControlTable["Increase Engine Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Increase Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "rshift"
                 ControlTable["Increase Engine Brake Key", string] = V:sub(14):trim():upper()
+                ControlTable["Increase Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "lcontrol"
                 ControlTable["Increase Engine Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Increase Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "rcontrol"
                 ControlTable["Increase Engine Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Increase Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "lalt"
                 ControlTable["Increase Engine Brake Key", string] = V:sub(11):trim():upper()
+                ControlTable["Increase Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "ralt"
                 ControlTable["Increase Engine Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Increase Engine Brake has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Increase Engine Brake Modifier", string] = ""
                 ControlTable["Increase Engine Brake Key", string] = V:trim():upper()
+                ControlTable["Increase Engine Brake has Modifier", number] = 0
             }
         }
 
@@ -349,42 +398,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "lshift"
                 ControlTable["Decrease Engine Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Decrease Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "rshift"
                 ControlTable["Decrease Engine Brake Key", string] = V:sub(14):trim():upper()
+                ControlTable["Decrease Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "lcontrol"
                 ControlTable["Decrease Engine Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Decrease Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "rcontrol"
                 ControlTable["Decrease Engine Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Decrease Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "lalt"
                 ControlTable["Decrease Engine Brake Key", string] = V:sub(11):trim():upper()
+                ControlTable["Decrease Engine Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "ralt"
                 ControlTable["Decrease Engine Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Decrease Engine Brake has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = ""
                 ControlTable["Decrease Engine Brake Key", string] = V:trim():upper()
+                ControlTable["Decrease Engine Brake has Modifier", number] = 0
             }
         }
 
@@ -394,42 +450,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Emergency Brake Modifier", string] = "lshift"
                 ControlTable["Emergency Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Emergency Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Emergency Brake Modifier", string] = "rshift"
                 ControlTable["Emergency Brake Key", string] = V:sub(14):trim():upper()
+                ControlTable["Emergency Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Emergency Brake Modifier", string] = "lcontrol"
                 ControlTable["Emergency Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Emergency Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Emergency Brake Modifier", string] = "rcontrol"
                 ControlTable["Emergency Brake Key", string] = V:sub(13):trim():upper()
+                ControlTable["Emergency Brake has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Emergency Brake Modifier", string] = "lalt"
                 ControlTable["Emergency Brake Key", string] = V:sub(11):trim():upper()
+                ControlTable["Emergency Brake has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Emergency Brake Modifier", string] = "ralt"
                 ControlTable["Emergency Brake Key", string] = V:sub(12):trim():upper()
+                ControlTable["Emergency Brake has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Emergency Brake Modifier", string] = ""
                 ControlTable["Emergency Brake Key", string] = V:trim():upper()
+                ControlTable["Emergency Brake has Modifier", number] = 0
             }
         }
 
@@ -439,42 +502,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Horn Modifier", string] = "lshift"
                 ControlTable["Horn Key", string] = V:sub(13):trim():upper()
+                ControlTable["Horn has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Horn Modifier", string] = "rshift"
                 ControlTable["Horn Key", string] = V:sub(14):trim():upper()
+                ControlTable["Horn has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Horn Modifier", string] = "lcontrol"
                 ControlTable["Horn Key", string] = V:sub(12):trim():upper()
+                ControlTable["Horn has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Horn Modifier", string] = "rcontrol"
                 ControlTable["Horn Key", string] = V:sub(13):trim():upper()
+                ControlTable["Horn has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Horn Modifier", string] = "lalt"
                 ControlTable["Horn Key", string] = V:sub(11):trim():upper()
+                ControlTable["Horn has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Horn Modifier", string] = "ralt"
                 ControlTable["Horn Key", string] = V:sub(12):trim():upper()
+                ControlTable["Horn has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Horn Modifier", string] = ""
                 ControlTable["Horn Key", string] = V:trim():upper()
+                ControlTable["Horn has Modifier", number] = 0
             }
         }
 
@@ -484,42 +554,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Bell Modifier", string] = "lshift"
                 ControlTable["Bell Key", string] = V:sub(13):trim():upper()
+                ControlTable["Bell has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Bell Modifier", string] = "rshift"
                 ControlTable["Bell Key", string] = V:sub(14):trim():upper()
+                ControlTable["Bell has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Bell Modifier", string] = "lcontrol"
                 ControlTable["Bell Key", string] = V:sub(12):trim():upper()
+                ControlTable["Bell has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Bell Modifier", string] = "rcontrol"
                 ControlTable["Bell Key", string] = V:sub(13):trim():upper()
+                ControlTable["Bell has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Bell Modifier", string] = "lalt"
                 ControlTable["Bell Key", string] = V:sub(11):trim():upper()
+                ControlTable["Bell has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Bell Modifier", string] = "ralt"
                 ControlTable["Bell Key", string] = V:sub(12):trim():upper()
+                ControlTable["Bell has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Bell Modifier", string] = ""
                 ControlTable["Bell Key", string] = V:trim():upper()
+                ControlTable["Bell has Modifier", number] = 0
             }
         }
 
@@ -529,42 +606,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Headlights Modifier", string] = "lshift"
                 ControlTable["Headlights Key", string] = V:sub(13):trim():upper()
+                ControlTable["Headlights has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Headlights Modifier", string] = "rshift"
                 ControlTable["Headlights Key", string] = V:sub(14):trim():upper()
+                ControlTable["Headlights has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Headlights Modifier", string] = "lcontrol"
                 ControlTable["Headlights Key", string] = V:sub(12):trim():upper()
+                ControlTable["Headlights has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Headlights Modifier", string] = "rcontrol"
                 ControlTable["Headlights Key", string] = V:sub(13):trim():upper()
+                ControlTable["Headlights has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Headlights Modifier", string] = "lalt"
                 ControlTable["Headlights Key", string] = V:sub(11):trim():upper()
+                ControlTable["Headlights has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Headlights Modifier", string] = "ralt"
                 ControlTable["Headlights Key", string] = V:sub(12):trim():upper()
+                ControlTable["Headlights has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Headlights Modifier", string] = ""
                 ControlTable["Headlights Key", string] = V:trim():upper()
+                ControlTable["Headlights has Modifier", number] = 0
             }
         }
 
@@ -574,42 +658,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
             {
                 ControlTable["Ditch Lights Modifier", string] = "lshift"
                 ControlTable["Ditch Lights Key", string] = V:sub(13):trim():upper()
+                ControlTable["Ditch Lights has Modifier", number] = 1
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Ditch Lights Modifier", string] = "rshift"
                 ControlTable["Ditch Lights Key", string] = V:sub(14):trim():upper()
+                ControlTable["Ditch Lights has Modifier", number] = 1
             }
 
             elseif (V:find("left ctrl + "))
             {
                 ControlTable["Ditch Lights Modifier", string] = "lcontrol"
                 ControlTable["Ditch Lights Key", string] = V:sub(12):trim():upper()
+                ControlTable["Ditch Lights has Modifier", number] = 1
             }
 
             elseif (V:find("right ctrl + "))
             {
                 ControlTable["Ditch Lights Modifier", string] = "rcontrol"
                 ControlTable["Ditch Lights Key", string] = V:sub(13):trim():upper()
+                ControlTable["Ditch Lights has Modifier", number] = 1
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Ditch Lights Modifier", string] = "lalt"
                 ControlTable["Ditch Lights Key", string] = V:sub(11):trim():upper()
+                ControlTable["Ditch Lights has Modifier", number] = 1
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Ditch Lights Modifier", string] = "ralt"
                 ControlTable["Ditch Lights Key", string] = V:sub(12):trim():upper()
+                ControlTable["Ditch Lights has Modifier", number] = 1
             }
 
             else
             {
                 ControlTable["Ditch Lights Modifier", string] = ""
                 ControlTable["Ditch Lights Key", string] = V:trim():upper()
+                ControlTable["Ditch Lights has Modifier", number] = 0
             }
         }
     }
@@ -656,178 +747,76 @@ function void playerControlsUpdate(Controls:table)
     local KeyboardControls = Controls["Controls", table]
     local Driver = Controls["TrainDriver", entity]
 
-    # Set the locomotive's direction.
-    # Here, the direction selector is no longer clamped.
-    # This is to allow the fault reporting system to alert the player when the direction selector is out of range.
-    if (KeyboardControls["Increase Direction Modifier", string] != "" & KeyboardControls["Increase Direction Key", string] != "")
+    local LeftModifierKeyPressed = bXor(Driver:keyPressed("lshift"), bXor(Driver:keyPressed("lcontrol"), Driver:keyPressed("lalt")))
+    local RightModifierKeyPressed = bXor(Driver:keyPressed("rshift"), bXor(Driver:keyPressed("rcontrol"), Driver:keyPressed("ralt")))
+    local ModifierKeyPressed = bXor(LeftModifierKeyPressed, RightModifierKeyPressed)
+
+    # I couldn't find a better way of doing this.
+    local IncreaseDirection = Driver:keyPressed(KeyboardControls["Increase Direction Key", string]) & (KeyboardControls["Increase Direction has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Increase Direction Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local DecreaseDirection = Driver:keyPressed(KeyboardControls["Decrease Direction Key", string]) & (KeyboardControls["Decrease Direction has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Decrease Direction Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local IncreaseThrottle = Driver:keyPressed(KeyboardControls["Increase Throttle Key", string]) & (KeyboardControls["Increase Throttle has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Increase Throttle Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local DecreaseThrottle = Driver:keyPressed(KeyboardControls["Decrease Throttle Key", string]) & (KeyboardControls["Decrease Throttle has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Decrease Throttle Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local IncreaseTrainBrake = Driver:keyPressed(KeyboardControls["Increase Train Brake Key", string]) & (KeyboardControls["Increase Train Brake has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Increase Train Brake Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local DecreaseTrainBrake = Driver:keyPressed(KeyboardControls["Decrease Train Brake Key", string]) & (KeyboardControls["Decrease Train Brake has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Decrease Train Brake Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local IncreaseEngineBrake = Driver:keyPressed(KeyboardControls["Increase Engine Brake Key", string]) & (KeyboardControls["Increase Engine Brake has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Increase Engine Brake Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local DecreaseEngineBrake = Driver:keyPressed(KeyboardControls["Decrease Engine Brake Key", string]) & (KeyboardControls["Decrease Engine Brake has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Decrease Engine Brake Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local EmergencyBrake = Driver:keyPressed(KeyboardControls["Emergency Brake Key", string]) & (KeyboardControls["Emergency Brake has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Emergency Brake Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local Horn = Driver:keyPressed(KeyboardControls["Horn Key", string]) & (KeyboardControls["Horn has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Horn Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local Bell = Driver:keyPressed(KeyboardControls["Bell Key", string]) & (KeyboardControls["Bell has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Bell Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local Headlights = Driver:keyPressed(KeyboardControls["Headlights Key", string]) & (KeyboardControls["Headlights has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Headlights Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+    local DitchLights = Driver:keyPressed(KeyboardControls["Ditch Lights Key", string]) & (KeyboardControls["Ditch Lights has Modifier", number] ? (Driver:keyPressed(KeyboardControls["Ditch Lights Modifier", string]) & ModifierKeyPressed) : !ModifierKeyPressed)
+
+    # Update the direction.
+    if (IncreaseDirection & !DecreaseDirection)
     {
-        if (Driver:keyPressed(KeyboardControls["Increase Direction Modifier", string]) & Driver:keyPressed(KeyboardControls["Increase Direction Key", string]))
-        {
-            Controls["Direction", number] = Controls["Direction", number] + 1
-        }
+        Controls["Direction", number] = Controls["Direction", number] + 1
+    }
+    elseif (DecreaseDirection & !IncreaseDirection)
+    {
+        Controls["Direction", number] = Controls["Direction", number] - 1
     }
 
-    elseif (KeyboardControls["Increase Direction Key", string] != "")
+    # Update the throttle.
+    elseif (IncreaseThrottle & !DecreaseThrottle)
     {
-        if (Driver:keyPressed(KeyboardControls["Increase Direction Key", string]))
-        {
-            Controls["Direction", number] = Controls["Direction", number] + 1
-        }
+        Controls["Throttle", number] = Controls["Throttle", number] + 1
+    }
+    elseif (DecreaseThrottle & !IncreaseThrottle)
+    {
+        Controls["Throttle", number] = Controls["Throttle", number] - 1
     }
 
-    if (KeyboardControls["Decrease Direction Modifier", string] != "" & KeyboardControls["Decrease Direction Key", string] != "")
+    # Update the train brake.
+    elseif (IncreaseTrainBrake & !DecreaseTrainBrake)
     {
-        if (Driver:keyPressed(KeyboardControls["Decrease Direction Modifier", string]) & Driver:keyPressed(KeyboardControls["Decrease Direction Key", string]))
-        {
-            Controls["Direction", number] = Controls["Direction", number] - 1
-        }
+        Controls["Brake", number] = Controls["Brake", number] + 1
+    }
+    elseif (DecreaseTrainBrake & !IncreaseTrainBrake)
+    {
+        Controls["Brake", number] = Controls["Brake", number] - 1
     }
 
-    elseif (KeyboardControls["Decrease Direction Key", string] != "")
+    # Update the engine brake.
+    elseif (IncreaseEngineBrake & !DecreaseEngineBrake)
     {
-        if (Driver:keyPressed(KeyboardControls["Decrease Direction Key", string]))
-        {
-            Controls["Direction", number] = Controls["Direction", number] - 1
-        }
+        Controls["Brake", number] = Controls["Brake", number] + 1
+    }
+    elseif (DecreaseEngineBrake & !IncreaseEngineBrake)
+    {
+        Controls["Brake", number] = Controls["Brake", number] - 1
     }
 
-    # Set the locomotive's throttle.
-    # Here, the throttle selector is no longer clamped.
-    # This is to allow the fault reporting system to alert the player when the throttle selector is out of range.
-    if (KeyboardControls["Increase Throttle Modifier", string] != "" & KeyboardControls["Increase Throttle Key", string] != "")
+    # Update the emergency brake.
+    elseif (EmergencyBrake)
     {
-        if (Driver:keyPressed(KeyboardControls["Increase Throttle Modifier", string]) & Driver:keyPressed(KeyboardControls["Increase Throttle Key", string]))
+        if (Controls["EmergencyBrake", number] == 0)
         {
-            Controls["Throttle", number] = Controls["Throttle", number] + 1
+            Controls["EmergencyBrake", number] = 1
         }
-    }
-
-    elseif (KeyboardControls["Increase Throttle Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Increase Throttle Key", string]))
+        else
         {
-            Controls["Throttle", number] = Controls["Throttle", number] + 1
-        }
-    }
-
-    if (KeyboardControls["Decrease Throttle Modifier", string] != "" & KeyboardControls["Decrease Throttle Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Decrease Throttle Modifier", string]) & Driver:keyPressed(KeyboardControls["Decrease Throttle Key", string]))
-        {
-            Controls["Throttle", number] = Controls["Throttle", number] - 1
-        }
-    }
-
-    elseif (KeyboardControls["Decrease Throttle Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Decrease Throttle Key", string]))
-        {
-            Controls["Throttle", number] = Controls["Throttle", number] - 1
-        }
-    }
-
-    # Set the train brake.
-    # Here, the brake selector is no longer clamped.
-    # This is to allow the fault reporting system to alert the player when the train brake selector is out of range.
-    if (KeyboardControls["Increase Train Brake Modifier", string] != "" & KeyboardControls["Increase Train Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Increase Train Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Increase Train Brake Key", string]))
-        {
-            Controls["Brake", number] = Controls["Brake", number] + 1
-        }
-    }
-
-    elseif (KeyboardControls["Increase Train Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Increase Train Brake Key", string]))
-        {
-            Controls["Brake", number] = Controls["Brake", number] + 1
-        }
-    }
-
-    if (KeyboardControls["Decrease Train Brake Modifier", string] != "" & KeyboardControls["Decrease Train Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Decrease Train Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Decrease Train Brake Key", string]))
-        {
-            Controls["Brake", number] = Controls["Brake", number] - 1
-        }
-    }
-
-    elseif (KeyboardControls["Decrease Train Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Decrease Train Brake Key", string]))
-        {
-            Controls["Brake", number] = Controls["Brake", number] - 1
-        }
-    }
-
-    # Set the engine brake.
-    # Here, the engine brake selector is no longer clamped.
-    # This is to allow the fault reporting system to alert the player when the engine brake selector is out of range.
-    if (KeyboardControls["Increase Engine Brake Modifier", string] != "" & KeyboardControls["Increase Engine Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Increase Engine Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Increase Engine Brake Key", string]))
-        {
-            Controls["Brake", number] = Controls["Brake", number] + 1
-        }
-    }
-
-    elseif (KeyboardControls["Increase Engine Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Increase Engine Brake Key", string]))
-        {
-            Controls["Brake", number] = Controls["Brake", number] + 1
-        }
-    }
-
-    if (KeyboardControls["Decrease Engine Brake Modifier", string] != "" & KeyboardControls["Decrease Engine Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Decrease Engine Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Decrease Engine Brake Key", string]))
-        {
-            Controls["Brake", number] = Controls["Brake", number] - 1
-        }
-    }
-
-    elseif (KeyboardControls["Decrease Engine Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Decrease Engine Brake Key", string]))
-        {
-            Controls["Brake", number] = Controls["Brake", number] - 1
-        }
-    }
-
-    # Set the emergency brake.
-    if (KeyboardControls["Emergency Brake Modifier", string] != "" & KeyboardControls["Emergency Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Emergency Brake Modifier", string]) & Driver:keyPressed(KeyboardControls["Emergency Brake Key", string]))
-        {
-            if (Controls["Emergency Brake", number] == 0)
-            {
-                Controls["Emergency Brake", number] = 1
-            }
-
-            else
-            {
-                Controls["Faults", table]["Message", string] = "Emergency brake is already applied."
-                Controls["Faults", table]["EmergencyBrake", number] = 1
-            }
-        }
-    }
-
-    elseif (KeyboardControls["Emergency Brake Key", string] != "")
-    {
-        if (Driver:keyPressed(KeyboardControls["Emergency Brake Key", string]))
-        {
-            if (Controls["Emergency Brake", number] == 0)
-            {
-                Controls["Emergency Brake", number] = 1
-            }
-
-            else
-            {
-                Controls["Faults", table]["Message", string] = "Emergency brake is already applied."
-                Controls["Faults", table]["EmergencyBrake", number] = 1
-            }
+            Controls["Faults", table]["Message", string] = "Emergency brake is already applied."
+            Controls["Faults", table]["EmergencyBrake", number] = 1
         }
     }
 }

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -21,3 +21,24 @@
 @name RailDriver/lib/controls/playerControls
 @persist PCDirection PCThrottle PCBrake PCEmergencyBrake PCHorn PCHeadlights PCDitchLights
 @persist PCTrainDriver:entity
+
+# This function initializes the player controls.
+# This function should be called once per player.
+function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, BrakeMap:table, TrainDriver:entity)
+{
+    local Controls = table()
+    Controls["Direction", number] = 0
+    Controls["Throttle", number] = 0
+    Controls["Brake", number] = 0
+    Controls["Horn", number] = 0
+    Controls["Bell", number] = 0
+    Controls["Headlights", number] = 0
+    Controls["DitchLights", number] = 0
+    Controls["TrainDriver", entity] = TrainDriver
+    Controls["Controls", array] = KeyboardControls:toArray()
+    Controls["ThrottleMap", array] = ThrottleMap:toArray()
+    Controls["BrakeMap", array] = BrakeMap:toArray()
+    runOnKeys(Controls["TrainDriver", entity], 1)
+    return Controls
+}
+

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -174,3 +174,15 @@ function number playerControlsGetBrake(Controls:table, PIDFMode:number)
     }
 }
 
+# This function is used to decode the keyboard controls.
+function array decodeKeyboardControls(KeyboardControls:table)
+{
+    local Controls = array()
+
+    foreach(K, V:string = KeyboardControls)
+    {
+        
+    }
+
+    return Controls
+}

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -22,6 +22,600 @@
 @persist PCDirection PCThrottle PCBrake PCEmergencyBrake PCHorn PCHeadlights PCDitchLights
 @persist PCTrainDriver:entity
 
+function table encodeKeyboardControls(KeyboardControls:table)
+{
+    local ControlTable = table()
+    foreach(K, V:string = KeyboardControls)
+    {
+        if (K == "Increase Reverser")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Increase Direction Modifier", string] = "lshift"
+                ControlTable["Increase Direction Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Increase Direction Modifier", string] = "rshift"
+                ControlTable["Increase Direction Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Increase Direction Modifier", string] = "lctrl"
+                ControlTable["Increase Direction Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Increase Direction Modifier", string] = "rctrl"
+                ControlTable["Increase Direction Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Increase Direction Modifier", string] = "lalt"
+                ControlTable["Increase Direction Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Increase Direction Modifier", string] = "ralt"
+                ControlTable["Increase Direction Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Increase Direction Modifier", string] = ""
+                ControlTable["Increase Direction Key", string] = V
+            }
+        }
+
+        if (K == "Decrease Reverser")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Decrease Direction Modifier", string] = "lshift"
+                ControlTable["Decrease Direction Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Decrease Direction Modifier", string] = "rshift"
+                ControlTable["Decrease Direction Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Decrease Direction Modifier", string] = "lctrl"
+                ControlTable["Decrease Direction Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Decrease Direction Modifier", string] = "rctrl"
+                ControlTable["Decrease Direction Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Decrease Direction Modifier", string] = "lalt"
+                ControlTable["Decrease Direction Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Decrease Direction Modifier", string] = "ralt"
+                ControlTable["Decrease Direction Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Decrease Direction Modifier", string] = ""
+                ControlTable["Decrease Direction Key", string] = V
+            }
+        }
+
+        if (K == "Increase Throttle")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Increase Throttle Modifier", string] = "lshift"
+                ControlTable["Increase Throttle Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Increase Throttle Modifier", string] = "rshift"
+                ControlTable["Increase Throttle Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Increase Throttle Modifier", string] = "lctrl"
+                ControlTable["Increase Throttle Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Increase Throttle Modifier", string] = "rctrl"
+                ControlTable["Increase Throttle Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Increase Throttle Modifier", string] = "lalt"
+                ControlTable["Increase Throttle Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Increase Throttle Modifier", string] = "ralt"
+                ControlTable["Increase Throttle Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Increase Throttle Modifier", string] = ""
+                ControlTable["Increase Throttle Key", string] = V
+            }
+        }
+
+        if (K == "Decrease Throttle")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Decrease Throttle Modifier", string] = "lshift"
+                ControlTable["Decrease Throttle Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Decrease Throttle Modifier", string] = "rshift"
+                ControlTable["Decrease Throttle Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Decrease Throttle Modifier", string] = "lctrl"
+                ControlTable["Decrease Throttle Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Decrease Throttle Modifier", string] = "rctrl"
+                ControlTable["Decrease Throttle Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Decrease Throttle Modifier", string] = "lalt"
+                ControlTable["Decrease Throttle Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Decrease Throttle Modifier", string] = "ralt"
+                ControlTable["Decrease Throttle Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Decrease Throttle Modifier", string] = ""
+                ControlTable["Decrease Throttle Key", string] = V
+            }
+        }
+
+        if (K == "Increase Train Brake")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Increase Train Brake Modifier", string] = "lshift"
+                ControlTable["Increase Train Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Increase Train Brake Modifier", string] = "rshift"
+                ControlTable["Increase Train Brake Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Increase Train Brake Modifier", string] = "lctrl"
+                ControlTable["Increase Train Brake Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Increase Train Brake Modifier", string] = "rctrl"
+                ControlTable["Increase Train Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Increase Train Brake Modifier", string] = "lalt"
+                ControlTable["Increase Train Brake Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Increase Train Brake Modifier", string] = "ralt"
+                ControlTable["Increase Train Brake Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Increase Train Brake Modifier", string] = ""
+                ControlTable["Increase Train Brake Key", string] = V
+            }
+        }
+
+        if (K == "Decrease Train Brake")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Decrease Train Brake Modifier", string] = "lshift"
+                ControlTable["Decrease Train Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Decrease Train Brake Modifier", string] = "rshift"
+                ControlTable["Decrease Train Brake Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Decrease Train Brake Modifier", string] = "lctrl"
+                ControlTable["Decrease Train Brake Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Decrease Train Brake Modifier", string] = "rctrl"
+                ControlTable["Decrease Train Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Decrease Train Brake Modifier", string] = "lalt"
+                ControlTable["Decrease Train Brake Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Decrease Train Brake Modifier", string] = "ralt"
+                ControlTable["Decrease Train Brake Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Decrease Train Brake Modifier", string] = ""
+                ControlTable["Decrease Train Brake Key", string] = V
+            }
+        }
+
+        if (K == "Increase Engine Brake")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Increase Engine Brake Modifier", string] = "lshift"
+                ControlTable["Increase Engine Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Increase Engine Brake Modifier", string] = "rshift"
+                ControlTable["Increase Engine Brake Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Increase Engine Brake Modifier", string] = "lctrl"
+                ControlTable["Increase Engine Brake Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Increase Engine Brake Modifier", string] = "rctrl"
+                ControlTable["Increase Engine Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Increase Engine Brake Modifier", string] = "lalt"
+                ControlTable["Increase Engine Brake Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Increase Engine Brake Modifier", string] = "ralt"
+                ControlTable["Increase Engine Brake Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Increase Engine Brake Modifier", string] = ""
+                ControlTable["Increase Engine Brake Key", string] = V
+            }
+        }
+
+        if (K == "Decrease Engine Brake")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Decrease Engine Brake Modifier", string] = "lshift"
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Decrease Engine Brake Modifier", string] = "rshift"
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Decrease Engine Brake Modifier", string] = "lctrl"
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Decrease Engine Brake Modifier", string] = "rctrl"
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Decrease Engine Brake Modifier", string] = "lalt"
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Decrease Engine Brake Modifier", string] = "ralt"
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Decrease Engine Brake Modifier", string] = ""
+                ControlTable["Decrease Engine Brake Key", string] = V
+            }
+        }
+
+        if (K == "Emergency Brake")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Emergency Brake Modifier", string] = "lshift"
+                ControlTable["Emergency Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Emergency Brake Modifier", string] = "rshift"
+                ControlTable["Emergency Brake Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Emergency Brake Modifier", string] = "lctrl"
+                ControlTable["Emergency Brake Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Emergency Brake Modifier", string] = "rctrl"
+                ControlTable["Emergency Brake Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Emergency Brake Modifier", string] = "lalt"
+                ControlTable["Emergency Brake Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Emergency Brake Modifier", string] = "ralt"
+                ControlTable["Emergency Brake Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Emergency Brake Modifier", string] = ""
+                ControlTable["Emergency Brake Key", string] = V
+            }
+        }
+
+        if (K == "Horn")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Horn Modifier", string] = "lshift"
+                ControlTable["Horn Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Horn Modifier", string] = "rshift"
+                ControlTable["Horn Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Horn Modifier", string] = "lctrl"
+                ControlTable["Horn Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Horn Modifier", string] = "rctrl"
+                ControlTable["Horn Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Horn Modifier", string] = "lalt"
+                ControlTable["Horn Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Horn Modifier", string] = "ralt"
+                ControlTable["Horn Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Horn Modifier", string] = ""
+                ControlTable["Horn Key", string] = V
+            }
+        }
+
+        if (K == "Bell")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Bell Modifier", string] = "lshift"
+                ControlTable["Bell Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Bell Modifier", string] = "rshift"
+                ControlTable["Bell Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Bell Modifier", string] = "lctrl"
+                ControlTable["Bell Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Bell Modifier", string] = "rctrl"
+                ControlTable["Bell Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Bell Modifier", string] = "lalt"
+                ControlTable["Bell Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Bell Modifier", string] = "ralt"
+                ControlTable["Bell Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Bell Modifier", string] = ""
+                ControlTable["Bell Key", string] = V
+            }
+        }
+
+        if (K == "Headlights")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Headlights Modifier", string] = "lshift"
+                ControlTable["Headlights Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Headlights Modifier", string] = "rshift"
+                ControlTable["Headlights Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Headlights Modifier", string] = "lctrl"
+                ControlTable["Headlights Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Headlights Modifier", string] = "rctrl"
+                ControlTable["Headlights Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Headlights Modifier", string] = "lalt"
+                ControlTable["Headlights Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Headlights Modifier", string] = "ralt"
+                ControlTable["Headlights Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Headlights Modifier", string] = ""
+                ControlTable["Headlights Key", string] = V
+            }
+        }
+
+        if (K == "Ditch Lights")
+        {
+            if (V:find("left shift + "))
+            {
+                ControlTable["Ditch Lights Modifier", string] = "lshift"
+                ControlTable["Ditch Lights Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("right shift + "))
+            {
+                ControlTable["Ditch Lights Modifier", string] = "rshift"
+                ControlTable["Ditch Lights Key", string] = V:sub(14)
+            }
+
+            elseif (V:find("left ctrl + "))
+            {
+                ControlTable["Ditch Lights Modifier", string] = "lctrl"
+                ControlTable["Ditch Lights Key", string] = V:sub(12)
+            }
+
+            elseif (V:find("right ctrl + "))
+            {
+                ControlTable["Ditch Lights Modifier", string] = "rctrl"
+                ControlTable["Ditch Lights Key", string] = V:sub(13)
+            }
+
+            elseif (V:find("left alt + "))
+            {
+                ControlTable["Ditch Lights Modifier", string] = "lalt"
+                ControlTable["Ditch Lights Key", string] = V:sub(11)
+            }
+
+            elseif (V:find("right alt + "))
+            {
+                ControlTable["Ditch Lights Modifier", string] = "ralt"
+                ControlTable["Ditch Lights Key", string] = V:sub(12)
+            }
+
+            else
+            {
+                ControlTable["Ditch Lights Modifier", string] = ""
+                ControlTable["Ditch Lights Key", string] = V
+            }
+        }
+    }
+
+    return ControlTable
+}
+
 # This function initializes the player controls.
 # This function should be called once per player.
 function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, BrakeMap:table, TrainDriver:entity)
@@ -36,7 +630,7 @@ function table playerControlsInit(KeyboardControls:table, ThrottleMap:table, Bra
     Controls["Headlights", number] = 0
     Controls["DitchLights", number] = 0
     Controls["TrainDriver", entity] = TrainDriver
-    Controls["Controls", table] = KeyboardControls
+    Controls["Controls", table] = encodeKeyboardControls(KeyboardControls)
 
     # 'table:toArray()' is bugged, so I am directly using the throttle and brake maps.
     Controls["ThrottleMap", table] = ThrottleMap

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -130,3 +130,25 @@ function number playerControlsGetDirection(Controls:table)
     return Controls["Direction", number]
 }
 
+# This function returns the player's throttle input based on the throttle map & what operating mode the PIDF controller is in.
+function number playerControlsGetThrottle(Controls:table, PIDFMode:number)
+{
+    # If the PIDF controller is in velocity mode, return the throttle map value.
+    if (PIDFMode == 0)
+    {
+        return Controls["ThrottleMap", array][Controls["Throttle", number], number]
+    }
+
+    # If the PIDF controller is in acceleration mode, return the throttle map value.
+    elseif (PIDFMode == 1)
+    {
+        return Controls["ThrottleMap", array][Controls["Throttle", number], number]
+    }
+
+    # If the PIDF controller is in torque mode, return the throttle value.
+    elseif (PIDFMode == 2)
+    {
+        return Controls["Throttle", number]
+    }
+}
+

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -1014,7 +1014,7 @@ function number playerControlsValid(Controls:table, Speed)
         # Velocity Mode.
         case "Velocity",
             # Brake is disabled in Velocity Mode. Any value set to the brake is invalid.
-            if (Brake > 0)
+            if (Brake != 0)
             {
                 Controls["Brake", number] = 0
                 Controls["Faults", table]["Message", string] = "Brake is disabled in Velocity Mode."

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -1141,3 +1141,20 @@ function number playerControlsClearBrakeFault(Controls:table)
         return 0
     }
 }
+
+# This function clears the emergency brake fault.
+# Returns true if the emergency brake fault was cleared.
+# False if the emergency brake fault was not previously set.
+function number playerControlsClearEmergencyBrakeFault(Controls:table)
+{
+    if (Controls["Faults", table]["Emergency Brake", number] == 1)
+    {
+        Controls["Faults", table]["Emergency Brake", number] = 0
+        return 1
+    }
+    else
+    {
+        Controls["Faults", table]["Message", string] = "Emergency Brake fault was not previously set."
+        return 0
+    }
+}

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -242,59 +242,44 @@ function number playerControlsGetDirection(Controls:table)
     return Controls["Direction", number]
 }
 
-# This function returns the player's throttle input based on the throttle map & what operating mode the PIDF controller is in.
-function number playerControlsGetThrottle(Controls:table, PIDFMode:number)
+# This function returns the throttle of the locomotive.
+function number playerControlsGetThrottle(Controls:table)
 {
-    # If the PIDF controller is in velocity mode, return the throttle map value.
-    if (PIDFMode == 0)
-    {
-        return Controls["ThrottleMap", array][Controls["Throttle", number], number]
-    }
-
-    # If the PIDF controller is in acceleration mode, return the throttle map value.
-    elseif (PIDFMode == 1)
-    {
-        return Controls["ThrottleMap", array][Controls["Throttle", number], number]
-    }
-
-    # If the PIDF controller is in torque mode, return the throttle value.
-    elseif (PIDFMode == 2)
-    {
-        return Controls["Throttle", number]
-    }
+    return Controls["Throttle", number]
 }
 
-# This function returns the player's brake input based on the brake map & what operating mode the PIDF controller is in.
-function number playerControlsGetBrake(Controls:table, PIDFMode:number)
+# This function returns the brake of the locomotive.
+function number playerControlsGetBrake(Controls:table)
 {
-    # Brake is always 0 if the PIDF controller is in velocity mode.
-    if (PIDFMode == 0)
-    {
-        return 0
-    }
-
-    # If the PIDF controller is in acceleration mode, return the brake map value.
-    elseif (PIDFMode == 1)
-    {
-        return Controls["BrakeMap", array][Controls["Brake", number], number]
-    }
-
-    # If the PIDF controller is in torque mode, return the brake value.
-    elseif (PIDFMode == 2)
-    {
-        return Controls["Brake", number]
-    }
+    return Controls["Brake", number]
 }
 
-# This function is used to decode the keyboard controls.
-function array decodeKeyboardControls(KeyboardControls:table)
+# This function returns the emergency brake of the locomotive.
+function number playerControlsGetEmergencyBrake(Controls:table)
 {
-    local Controls = array()
+    return Controls["EmergencyBrake", number]
+}
 
-    foreach(K, V:string = KeyboardControls)
-    {
-        
-    }
+# This function returns the horn of the locomotive.
+function number playerControlsGetHorn(Controls:table)
+{
+    return Controls["Horn", number]
+}
 
-    return Controls
+# This function returns the bell of the locomotive.
+function number playerControlsGetBell(Controls:table)
+{
+    return Controls["Bell", number]
+}
+
+# This function returns the headlights of the locomotive.
+function number playerControlsGetHeadlights(Controls:table)
+{
+    return Controls["Headlights", number]
+}
+
+# This function returns the ditch lights of the locomotive.
+function number playerControlsGetDitchLights(Controls:table)
+{
+    return Controls["DitchLights", number]
 }

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -27,48 +27,49 @@ function table encodeKeyboardControls(KeyboardControls:table)
     local ControlTable = table()
     foreach(K, V:string = KeyboardControls)
     {
+        V:lower()
         if (K == "Increase Reverser")
         {
             if (V:find("left shift + "))
             {
                 ControlTable["Increase Direction Modifier", string] = "lshift"
-                ControlTable["Increase Direction Key", string] = V:sub(13)
+                ControlTable["Increase Direction Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Increase Direction Modifier", string] = "rshift"
-                ControlTable["Increase Direction Key", string] = V:sub(14)
+                ControlTable["Increase Direction Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Increase Direction Modifier", string] = "lctrl"
-                ControlTable["Increase Direction Key", string] = V:sub(12)
+                ControlTable["Increase Direction Modifier", string] = "lcontrol"
+                ControlTable["Increase Direction Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Increase Direction Modifier", string] = "rctrl"
-                ControlTable["Increase Direction Key", string] = V:sub(13)
+                ControlTable["Increase Direction Modifier", string] = "rcontrol"
+                ControlTable["Increase Direction Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Increase Direction Modifier", string] = "lalt"
-                ControlTable["Increase Direction Key", string] = V:sub(11)
+                ControlTable["Increase Direction Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Increase Direction Modifier", string] = "ralt"
-                ControlTable["Increase Direction Key", string] = V:sub(12)
+                ControlTable["Increase Direction Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Increase Direction Modifier", string] = ""
-                ControlTable["Increase Direction Key", string] = V
+                ControlTable["Increase Direction Key", string] = V:trim():upper()
             }
         }
 
@@ -77,43 +78,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Decrease Direction Modifier", string] = "lshift"
-                ControlTable["Decrease Direction Key", string] = V:sub(13)
+                ControlTable["Decrease Direction Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Decrease Direction Modifier", string] = "rshift"
-                ControlTable["Decrease Direction Key", string] = V:sub(14)
+                ControlTable["Decrease Direction Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Decrease Direction Modifier", string] = "lctrl"
-                ControlTable["Decrease Direction Key", string] = V:sub(12)
+                ControlTable["Decrease Direction Modifier", string] = "lcontrol"
+                ControlTable["Decrease Direction Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Decrease Direction Modifier", string] = "rctrl"
-                ControlTable["Decrease Direction Key", string] = V:sub(13)
+                ControlTable["Decrease Direction Modifier", string] = "rcontrol"
+                ControlTable["Decrease Direction Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Decrease Direction Modifier", string] = "lalt"
-                ControlTable["Decrease Direction Key", string] = V:sub(11)
+                ControlTable["Decrease Direction Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Decrease Direction Modifier", string] = "ralt"
-                ControlTable["Decrease Direction Key", string] = V:sub(12)
+                ControlTable["Decrease Direction Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Decrease Direction Modifier", string] = ""
-                ControlTable["Decrease Direction Key", string] = V
+                ControlTable["Decrease Direction Key", string] = V:trim():upper()
             }
         }
 
@@ -122,43 +123,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Increase Throttle Modifier", string] = "lshift"
-                ControlTable["Increase Throttle Key", string] = V:sub(13)
+                ControlTable["Increase Throttle Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Increase Throttle Modifier", string] = "rshift"
-                ControlTable["Increase Throttle Key", string] = V:sub(14)
+                ControlTable["Increase Throttle Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Increase Throttle Modifier", string] = "lctrl"
-                ControlTable["Increase Throttle Key", string] = V:sub(12)
+                ControlTable["Increase Throttle Modifier", string] = "lcontrol"
+                ControlTable["Increase Throttle Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Increase Throttle Modifier", string] = "rctrl"
-                ControlTable["Increase Throttle Key", string] = V:sub(13)
+                ControlTable["Increase Throttle Modifier", string] = "rcontrol"
+                ControlTable["Increase Throttle Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Increase Throttle Modifier", string] = "lalt"
-                ControlTable["Increase Throttle Key", string] = V:sub(11)
+                ControlTable["Increase Throttle Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Increase Throttle Modifier", string] = "ralt"
-                ControlTable["Increase Throttle Key", string] = V:sub(12)
+                ControlTable["Increase Throttle Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Increase Throttle Modifier", string] = ""
-                ControlTable["Increase Throttle Key", string] = V
+                ControlTable["Increase Throttle Key", string] = V:trim():upper()
             }
         }
 
@@ -167,43 +168,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Decrease Throttle Modifier", string] = "lshift"
-                ControlTable["Decrease Throttle Key", string] = V:sub(13)
+                ControlTable["Decrease Throttle Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Decrease Throttle Modifier", string] = "rshift"
-                ControlTable["Decrease Throttle Key", string] = V:sub(14)
+                ControlTable["Decrease Throttle Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Decrease Throttle Modifier", string] = "lctrl"
-                ControlTable["Decrease Throttle Key", string] = V:sub(12)
+                ControlTable["Decrease Throttle Modifier", string] = "lcontrol"
+                ControlTable["Decrease Throttle Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Decrease Throttle Modifier", string] = "rctrl"
-                ControlTable["Decrease Throttle Key", string] = V:sub(13)
+                ControlTable["Decrease Throttle Modifier", string] = "rcontrol"
+                ControlTable["Decrease Throttle Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Decrease Throttle Modifier", string] = "lalt"
-                ControlTable["Decrease Throttle Key", string] = V:sub(11)
+                ControlTable["Decrease Throttle Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Decrease Throttle Modifier", string] = "ralt"
-                ControlTable["Decrease Throttle Key", string] = V:sub(12)
+                ControlTable["Decrease Throttle Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Decrease Throttle Modifier", string] = ""
-                ControlTable["Decrease Throttle Key", string] = V
+                ControlTable["Decrease Throttle Key", string] = V:trim():upper()
             }
         }
 
@@ -212,43 +213,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Increase Train Brake Modifier", string] = "lshift"
-                ControlTable["Increase Train Brake Key", string] = V:sub(13)
+                ControlTable["Increase Train Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Increase Train Brake Modifier", string] = "rshift"
-                ControlTable["Increase Train Brake Key", string] = V:sub(14)
+                ControlTable["Increase Train Brake Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Increase Train Brake Modifier", string] = "lctrl"
-                ControlTable["Increase Train Brake Key", string] = V:sub(12)
+                ControlTable["Increase Train Brake Modifier", string] = "lcontrol"
+                ControlTable["Increase Train Brake Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Increase Train Brake Modifier", string] = "rctrl"
-                ControlTable["Increase Train Brake Key", string] = V:sub(13)
+                ControlTable["Increase Train Brake Modifier", string] = "rcontrol"
+                ControlTable["Increase Train Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Increase Train Brake Modifier", string] = "lalt"
-                ControlTable["Increase Train Brake Key", string] = V:sub(11)
+                ControlTable["Increase Train Brake Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Increase Train Brake Modifier", string] = "ralt"
-                ControlTable["Increase Train Brake Key", string] = V:sub(12)
+                ControlTable["Increase Train Brake Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Increase Train Brake Modifier", string] = ""
-                ControlTable["Increase Train Brake Key", string] = V
+                ControlTable["Increase Train Brake Key", string] = V:trim():upper()
             }
         }
 
@@ -257,43 +258,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "lshift"
-                ControlTable["Decrease Train Brake Key", string] = V:sub(13)
+                ControlTable["Decrease Train Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "rshift"
-                ControlTable["Decrease Train Brake Key", string] = V:sub(14)
+                ControlTable["Decrease Train Brake Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Decrease Train Brake Modifier", string] = "lctrl"
-                ControlTable["Decrease Train Brake Key", string] = V:sub(12)
+                ControlTable["Decrease Train Brake Modifier", string] = "lcontrol"
+                ControlTable["Decrease Train Brake Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Decrease Train Brake Modifier", string] = "rctrl"
-                ControlTable["Decrease Train Brake Key", string] = V:sub(13)
+                ControlTable["Decrease Train Brake Modifier", string] = "rcontrol"
+                ControlTable["Decrease Train Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "lalt"
-                ControlTable["Decrease Train Brake Key", string] = V:sub(11)
+                ControlTable["Decrease Train Brake Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Decrease Train Brake Modifier", string] = "ralt"
-                ControlTable["Decrease Train Brake Key", string] = V:sub(12)
+                ControlTable["Decrease Train Brake Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Decrease Train Brake Modifier", string] = ""
-                ControlTable["Decrease Train Brake Key", string] = V
+                ControlTable["Decrease Train Brake Key", string] = V:trim():upper()
             }
         }
 
@@ -302,43 +303,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "lshift"
-                ControlTable["Increase Engine Brake Key", string] = V:sub(13)
+                ControlTable["Increase Engine Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "rshift"
-                ControlTable["Increase Engine Brake Key", string] = V:sub(14)
+                ControlTable["Increase Engine Brake Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Increase Engine Brake Modifier", string] = "lctrl"
-                ControlTable["Increase Engine Brake Key", string] = V:sub(12)
+                ControlTable["Increase Engine Brake Modifier", string] = "lcontrol"
+                ControlTable["Increase Engine Brake Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Increase Engine Brake Modifier", string] = "rctrl"
-                ControlTable["Increase Engine Brake Key", string] = V:sub(13)
+                ControlTable["Increase Engine Brake Modifier", string] = "rcontrol"
+                ControlTable["Increase Engine Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "lalt"
-                ControlTable["Increase Engine Brake Key", string] = V:sub(11)
+                ControlTable["Increase Engine Brake Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Increase Engine Brake Modifier", string] = "ralt"
-                ControlTable["Increase Engine Brake Key", string] = V:sub(12)
+                ControlTable["Increase Engine Brake Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Increase Engine Brake Modifier", string] = ""
-                ControlTable["Increase Engine Brake Key", string] = V
+                ControlTable["Increase Engine Brake Key", string] = V:trim():upper()
             }
         }
 
@@ -347,43 +348,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "lshift"
-                ControlTable["Decrease Engine Brake Key", string] = V:sub(13)
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "rshift"
-                ControlTable["Decrease Engine Brake Key", string] = V:sub(14)
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Decrease Engine Brake Modifier", string] = "lctrl"
-                ControlTable["Decrease Engine Brake Key", string] = V:sub(12)
+                ControlTable["Decrease Engine Brake Modifier", string] = "lcontrol"
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Decrease Engine Brake Modifier", string] = "rctrl"
-                ControlTable["Decrease Engine Brake Key", string] = V:sub(13)
+                ControlTable["Decrease Engine Brake Modifier", string] = "rcontrol"
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "lalt"
-                ControlTable["Decrease Engine Brake Key", string] = V:sub(11)
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = "ralt"
-                ControlTable["Decrease Engine Brake Key", string] = V:sub(12)
+                ControlTable["Decrease Engine Brake Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Decrease Engine Brake Modifier", string] = ""
-                ControlTable["Decrease Engine Brake Key", string] = V
+                ControlTable["Decrease Engine Brake Key", string] = V:trim():upper()
             }
         }
 
@@ -392,43 +393,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Emergency Brake Modifier", string] = "lshift"
-                ControlTable["Emergency Brake Key", string] = V:sub(13)
+                ControlTable["Emergency Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Emergency Brake Modifier", string] = "rshift"
-                ControlTable["Emergency Brake Key", string] = V:sub(14)
+                ControlTable["Emergency Brake Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Emergency Brake Modifier", string] = "lctrl"
-                ControlTable["Emergency Brake Key", string] = V:sub(12)
+                ControlTable["Emergency Brake Modifier", string] = "lcontrol"
+                ControlTable["Emergency Brake Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Emergency Brake Modifier", string] = "rctrl"
-                ControlTable["Emergency Brake Key", string] = V:sub(13)
+                ControlTable["Emergency Brake Modifier", string] = "rcontrol"
+                ControlTable["Emergency Brake Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Emergency Brake Modifier", string] = "lalt"
-                ControlTable["Emergency Brake Key", string] = V:sub(11)
+                ControlTable["Emergency Brake Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Emergency Brake Modifier", string] = "ralt"
-                ControlTable["Emergency Brake Key", string] = V:sub(12)
+                ControlTable["Emergency Brake Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Emergency Brake Modifier", string] = ""
-                ControlTable["Emergency Brake Key", string] = V
+                ControlTable["Emergency Brake Key", string] = V:trim():upper()
             }
         }
 
@@ -437,43 +438,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Horn Modifier", string] = "lshift"
-                ControlTable["Horn Key", string] = V:sub(13)
+                ControlTable["Horn Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Horn Modifier", string] = "rshift"
-                ControlTable["Horn Key", string] = V:sub(14)
+                ControlTable["Horn Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Horn Modifier", string] = "lctrl"
-                ControlTable["Horn Key", string] = V:sub(12)
+                ControlTable["Horn Modifier", string] = "lcontrol"
+                ControlTable["Horn Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Horn Modifier", string] = "rctrl"
-                ControlTable["Horn Key", string] = V:sub(13)
+                ControlTable["Horn Modifier", string] = "rcontrol"
+                ControlTable["Horn Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Horn Modifier", string] = "lalt"
-                ControlTable["Horn Key", string] = V:sub(11)
+                ControlTable["Horn Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Horn Modifier", string] = "ralt"
-                ControlTable["Horn Key", string] = V:sub(12)
+                ControlTable["Horn Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Horn Modifier", string] = ""
-                ControlTable["Horn Key", string] = V
+                ControlTable["Horn Key", string] = V:trim():upper()
             }
         }
 
@@ -482,43 +483,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Bell Modifier", string] = "lshift"
-                ControlTable["Bell Key", string] = V:sub(13)
+                ControlTable["Bell Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Bell Modifier", string] = "rshift"
-                ControlTable["Bell Key", string] = V:sub(14)
+                ControlTable["Bell Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Bell Modifier", string] = "lctrl"
-                ControlTable["Bell Key", string] = V:sub(12)
+                ControlTable["Bell Modifier", string] = "lcontrol"
+                ControlTable["Bell Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Bell Modifier", string] = "rctrl"
-                ControlTable["Bell Key", string] = V:sub(13)
+                ControlTable["Bell Modifier", string] = "rcontrol"
+                ControlTable["Bell Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Bell Modifier", string] = "lalt"
-                ControlTable["Bell Key", string] = V:sub(11)
+                ControlTable["Bell Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Bell Modifier", string] = "ralt"
-                ControlTable["Bell Key", string] = V:sub(12)
+                ControlTable["Bell Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Bell Modifier", string] = ""
-                ControlTable["Bell Key", string] = V
+                ControlTable["Bell Key", string] = V:trim():upper()
             }
         }
 
@@ -527,43 +528,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Headlights Modifier", string] = "lshift"
-                ControlTable["Headlights Key", string] = V:sub(13)
+                ControlTable["Headlights Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Headlights Modifier", string] = "rshift"
-                ControlTable["Headlights Key", string] = V:sub(14)
+                ControlTable["Headlights Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Headlights Modifier", string] = "lctrl"
-                ControlTable["Headlights Key", string] = V:sub(12)
+                ControlTable["Headlights Modifier", string] = "lcontrol"
+                ControlTable["Headlights Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Headlights Modifier", string] = "rctrl"
-                ControlTable["Headlights Key", string] = V:sub(13)
+                ControlTable["Headlights Modifier", string] = "rcontrol"
+                ControlTable["Headlights Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Headlights Modifier", string] = "lalt"
-                ControlTable["Headlights Key", string] = V:sub(11)
+                ControlTable["Headlights Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Headlights Modifier", string] = "ralt"
-                ControlTable["Headlights Key", string] = V:sub(12)
+                ControlTable["Headlights Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Headlights Modifier", string] = ""
-                ControlTable["Headlights Key", string] = V
+                ControlTable["Headlights Key", string] = V:trim():upper()
             }
         }
 
@@ -572,43 +573,43 @@ function table encodeKeyboardControls(KeyboardControls:table)
             if (V:find("left shift + "))
             {
                 ControlTable["Ditch Lights Modifier", string] = "lshift"
-                ControlTable["Ditch Lights Key", string] = V:sub(13)
+                ControlTable["Ditch Lights Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("right shift + "))
             {
                 ControlTable["Ditch Lights Modifier", string] = "rshift"
-                ControlTable["Ditch Lights Key", string] = V:sub(14)
+                ControlTable["Ditch Lights Key", string] = V:sub(14):trim():upper()
             }
 
             elseif (V:find("left ctrl + "))
             {
-                ControlTable["Ditch Lights Modifier", string] = "lctrl"
-                ControlTable["Ditch Lights Key", string] = V:sub(12)
+                ControlTable["Ditch Lights Modifier", string] = "lcontrol"
+                ControlTable["Ditch Lights Key", string] = V:sub(12):trim():upper()
             }
 
             elseif (V:find("right ctrl + "))
             {
-                ControlTable["Ditch Lights Modifier", string] = "rctrl"
-                ControlTable["Ditch Lights Key", string] = V:sub(13)
+                ControlTable["Ditch Lights Modifier", string] = "rcontrol"
+                ControlTable["Ditch Lights Key", string] = V:sub(13):trim():upper()
             }
 
             elseif (V:find("left alt + "))
             {
                 ControlTable["Ditch Lights Modifier", string] = "lalt"
-                ControlTable["Ditch Lights Key", string] = V:sub(11)
+                ControlTable["Ditch Lights Key", string] = V:sub(11):trim():upper()
             }
 
             elseif (V:find("right alt + "))
             {
                 ControlTable["Ditch Lights Modifier", string] = "ralt"
-                ControlTable["Ditch Lights Key", string] = V:sub(12)
+                ControlTable["Ditch Lights Key", string] = V:sub(12):trim():upper()
             }
 
             else
             {
                 ControlTable["Ditch Lights Modifier", string] = ""
-                ControlTable["Ditch Lights Key", string] = V
+                ControlTable["Ditch Lights Key", string] = V:trim():upper()
             }
         }
     }

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -134,6 +134,66 @@ function void playerControlsUpdate(Controls:table)
                 }
             }
 
+            # Increase brake if the increase brake key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][5, string])
+            {
+                # Increase brake by 1.
+                Controls["Brake", number] = Controls["Brake", number] + 1
+
+                # Get the brake map.
+                local BrkMap = Controls["BrakeMap", table]
+
+                # Clamp the brake to the maximum value in the brake map.
+                # Each brake map has its own minimum & maximum values.
+                switch(BrkMap["Brake Input Type", string])
+                {
+                    # Velocity Mode.
+                    case "Velocity",
+                        # Brake is disabled in this mode.
+                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, 0)
+                    break
+
+                    # Acceleration Mode.
+                    case "Acceleration",
+                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, BrkMap["Deceleration Setpoint", array]:count())
+                    break
+
+                    # Torque Mode.
+                    case "Torque",
+                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, BrkMap["Torque Setpoint", array]:count())
+                    break
+                }
+            }
+
+            # Decrease brake if the decrease brake key is pressed.
+            if (KeyState == 1 & KeyPressed == Controls["Controls", array][6, string])
+            {
+                # Decrease brake by 1.
+                Controls["Brake", number] = Controls["Brake", number] - 1
+
+                # Get the brake map.
+                local BrkMap = Controls["BrakeMap", table]
+
+                # Clamp the brake to the minimum value in the brake map.
+                # Each brake map has its own minimum & maximum values.
+                switch(BrkMap["Brake Input Type", string])
+                {
+                    # Velocity Mode.
+                    case "Velocity",
+                        # Brake is disabled in this mode.
+                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, 0)
+                    break
+
+                    # Acceleration Mode.
+                    case "Acceleration",
+                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, BrkMap["Deceleration Setpoint", array]:count())
+                    break
+
+                    # Torque Mode.
+                    case "Torque",
+                        Controls["Brake", number] = clamp(Controls["Brake", number], 0, BrkMap["Torque Setpoint", array]:count())
+                    break
+                }
             }
 
             # Set emergency brake if the emergency brake key is pressed.

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -1,0 +1,23 @@
+#[
+    This script header is a part of the RailDriver project.
+
+    RailDriver. Smart Locomotive Control script for Garry's Mod Train Build Servers.
+    Copyright © 2022, Cassandra "ZZ Cat" Robinson. All rights reserved.
+
+    This E2 script is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This E2 script is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this E2 script.  If not, see <https://www.gnu.org/licenses/>.
+]#
+
+@name RailDriver/lib/controls/playerControls
+@persist PCDirection PCThrottle PCBrake PCEmergencyBrake PCHorn PCHeadlights PCDitchLights
+@persist PCTrainDriver:entity

--- a/lib/controls/playerControls.txt
+++ b/lib/controls/playerControls.txt
@@ -124,3 +124,9 @@ function void playerControlsUpdate(Controls:table)
     }
 }
 
+# This function returns the direction of the locomotive.
+function number playerControlsGetDirection(Controls:table)
+{
+    return Controls["Direction", number]
+}
+

--- a/lib/sensors/speedometer.txt
+++ b/lib/sensors/speedometer.txt
@@ -37,6 +37,10 @@ function table speedometerInit(InputPos:entity, InputNeg:entity)
     S["!Error Hyst. High", number] = -S["Error Hyst. High", number]
     S["!Error Hyst. Low", number] = -S["Error Hyst. Low", number]
 
+    S["Filter Output", number] = 0
+    S["Filter Coefficient", number] = 0.5
+    S["Filter Time Constant", number] = 1 / (2 * pi() * S["Filter Coefficient", number])
+
     S["SPEEDOMETER FAULT: Speed Data Invalid", number] = 0
     S["SPEEDOMETER FAULT: Speed Data Invalid Latch", number] = 0
     S["SPEEDOMETER FAULT: Speed Direction Incorrect", number] = 0
@@ -197,6 +201,105 @@ function number speedometerGetSpeed(S:table, Direction)
     }
 
     return abs(Output)
+}
+
+# This function applies a low-pass filter to the speedometer's data.
+# This is done to reduce the amount of noise that is present in the speedometer's data.
+function number speedometerFilter(S:table, Input)
+{
+    # The filter's output is calculated from the filter's input.
+    local Output = 0
+    Output = (Input * S["Filter Coefficient", number]) + (S["Filter Output", number] * (1 - S["Filter Coefficient", number]))
+
+    # The filter's output is stored for use in the next iteration of the filter.
+    S["Filter Output", number] = Output
+
+    return Output
+}
+
+# This function calculates the low-pass filter's coefficient.
+# This is done to ensure that the filter's cutoff frequency is correct.
+function void speedometerFilterCoefficient(S:table, CutoffFrequency)
+{
+    # The filter's cutoff frequency is calculated from the filter's coefficient.
+    local Coefficient = 0
+    Coefficient = 1 / (2 * pi() * CutoffFrequency * S["Filter Time Constant", number])
+
+    # The filter's coefficient is stored for use in the filter.
+    S["Filter Coefficient", number] = Coefficient
+
+}
+
+# This function calculates the low-pass filter's time constant.
+# This is done to ensure that the filter's cutoff frequency is correct.
+function void speedometerFilterTimeConstant(S:table, CutoffFrequency)
+{
+    # The filter's cutoff frequency is calculated from the filter's time constant.
+    local TimeConstant = 0
+    TimeConstant = 1 / (2 * pi() * CutoffFrequency * S["Filter Coefficient", number])
+
+    # The filter's time constant is stored for use in the filter.
+    S["Filter Time Constant", number] = TimeConstant
+}
+
+# This function calculates the low-pass filter's cutoff frequency.
+# This is done to ensure that the filter's cutoff frequency is correct.
+function number speedometerFilterCutoffFrequency(S:table, Coefficient, TimeConstant)
+{
+    # The filter's cutoff frequency is calculated from the filter's coefficient and time constant.
+    local CutoffFrequency = 0
+    CutoffFrequency = 1 / (2 * pi() * Coefficient * TimeConstant)
+
+    return CutoffFrequency
+}
+
+# This function gets the low-pass filter's coefficient.
+function number speedometerGetFilterCoefficient(S:table)
+{
+    return S["Filter Coefficient", number]
+}
+
+# This function gets the low-pass filter's time constant.
+function number speedometerGetFilterTimeConstant(S:table)
+{
+    return S["Filter Time Constant", number]
+}
+
+# This function gets the low-pass filter's cutoff frequency.
+function number speedometerGetFilterCutoffFrequency(S:table)
+{
+    return speedometerFilterCutoffFrequency(S, S["Filter Coefficient", number], S["Filter Time Constant", number])
+}
+
+# This function gets the low-pass filter's cutoff frequency in hertz.
+function number speedometerGetFilterCutOffFrequencyHz(S:table)
+{
+    return speedometerFilterCutoffFrequency(S, S["Filter Coefficient", number], S["Filter Time Constant", number]) / 1000
+}
+
+# This function gets the low-pass filter's time constant in milliseconds.
+function number speedometerGetFilterTimeConstantMs(S:table)
+{
+    return S["Filter Time Constant", number]
+}
+
+# This function sets the low-pass filter's coefficient.
+function void speedometerSetFilterCoefficient(S:table, Coefficient)
+{
+    S["Filter Coefficient", number] = Coefficient
+}
+
+# This function sets the low-pass filter's time constant.
+function void speedometerSetFilterTimeConstant(S:table, TimeConstant)
+{
+    S["Filter Time Constant", number] = TimeConstant
+}
+
+# This function sets the low-pass filter's cutoff frequency.
+function void speedometerSetFilterCutoffFrequency(S:table, CutoffFrequency)
+{
+    speedometerFilterCoefficient(S, CutoffFrequency)
+    speedometerFilterTimeConstant(S, CutoffFrequency)
 }
 
 function number speedometerDirectionIsValid(S:table)

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -110,7 +110,7 @@ function number semSmartParentE2toLocoBody()
     if (SemE2IsParentedTo)
     {
         # Already parented, nothing to do.
-        return 0
+        return 1
     }
 
     # If E2 is not parented, first remove any existing welds.

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -131,7 +131,7 @@ function number semSmartUnparentE2fromLocoBody()
     if (!SemE2IsParentedTo)
     {
         # Not parented, nothing to do.
-        return 0
+        return 1
     }
 
     # Replace the E2's parent with a weld.

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -135,7 +135,7 @@ function number semSmartUnparentE2fromLocoBody()
     }
 
     # Replace the E2's parent with a weld.
-    SemE2:deparent(SemE2IsParentedTo)
+    SemE2:deparent()
     weld(SemE2, SemE2IsParentedTo)
     SemE2IsWeldedTo = SemE2IsParentedTo
     SemE2IsParentedTo = noentity()


### PR DESCRIPTION
This PR adds fully functional player controls to RailDriver.

Player controls are fully customizable. Currently, this requires modifiying the main script in order to customize the controls. The controls are converted over from plain English to Garry's Mod's keyboard controls enumerations on initialization (when the E2 is first spawned in).

This PR adds support for standard keys & modifier + key combinations.
Use of multiple modifier combinations with keys currently is not supported (It may be added in the future, if this gets requested).