### PR TITLE
Fix for two false positives.

### DIFF
--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -83,7 +83,7 @@ if (first() | duped())
         # This prevents the E2 from being permanently locked.
         # This also prevents the E2 from being permanently parented to the locomotive.
         semUnlockE2()
-        semSmartUnparentE2FromLocoBody()
+        semSmartUnparentE2fromLocoBody()
         printColor(vec(255, 0, 0), "[RailDriver | Error]: ", vec(255, 255, 255), Exception)
     }
 }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -30,6 +30,12 @@ if (first() | duped())
 
     try
     {
+        # Initialize Smart Entity Management library.
+        if(!semInit())
+        {
+            error("Failed to initialize Smart Entity Management library.")
+        }
+
         # Lock E2 so it can't be edited by other players in multiplayer mode.
         # This prevents players from accidentally breaking the E2.
         if (!semLockE2())

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -57,9 +57,10 @@ if (first() | duped())
         }
 
         # Check that the trucks are valid physics objects.
-        for (I = 1, I <= Trucks:count(), I++)
+        for (I = 1, Trucks:count())
         {
-            if (!Trucks[I, entity]:isValid() | !Trucks[I, entity]:isValidPhysics())
+            # Use an alternative version, to prevent false positives.
+            if (Trucks[I, entity] == noentity())
             {
                 error("Truck " + I + " is not a valid physics object.")
             }

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -110,7 +110,7 @@ function number semSmartParentE2toLocoBody()
     if (SemE2IsParentedTo)
     {
         # Already parented, nothing to do.
-        return 0
+        return 1
     }
 
     # If E2 is not parented, first remove any existing welds.

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -131,7 +131,7 @@ function number semSmartUnparentE2fromLocoBody()
     if (!SemE2IsParentedTo)
     {
         # Not parented, nothing to do.
-        return 0
+        return 1
     }
 
     # Replace the E2's parent with a weld.

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -135,7 +135,7 @@ function number semSmartUnparentE2fromLocoBody()
     }
 
     # Replace the E2's parent with a weld.
-    SemE2:deparent(SemE2IsParentedTo)
+    SemE2:deparent()
     weld(SemE2, SemE2IsParentedTo)
     SemE2IsWeldedTo = SemE2IsParentedTo
     SemE2IsParentedTo = noentity()


### PR DESCRIPTION
This PR fixes two false positives.
One with Smart Entity Management, where an entity that it discovered was erroneously being reported as false.

The second one was with the trucks, themselves. Apparently, when the trucks are axis constrained (or have any constraint for that matter), they don't have any valid physics. So, their 'entity:isValid()' & 'entity:isValidPhysics()' was returning false.

A workaround for this is to compare the Trucks' entity data to 'noentity()' to detect an invalid object.

That's Expression2 for ya.

Oh, & while I was at it, I did a couple of minor fixes as well. You're welcome. =^/.~=