### PR TITLE
Only lock E2 once everything else has successfully initialized.

### DIFF
--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -53,21 +53,6 @@ if (first() | duped())
         # Initialize Smart Entity Management.
         if (semInit())
         {
-            #[
-                Lock the E2, so that it can't be deleted or edited by anyone
-                except you.
-
-                This is not a security measure, as the E2 can still be
-                deleted or edited by you. It is only a convenience measure,
-                to prevent other users from accidentally or maliciously
-                deleting or editing the E2, which would cause RailDriver to
-                stop working.
-
-                You can still update the E2 by using the "Update" button in
-                the Remote Upload menu of the Expression 2 Tool Gun.
-            ]#
-            semLockE2()
-            assert(semE2IsLocked(), "Failed to lock E2.")
 
             if (!semParentToLocomotive())
             {
@@ -160,24 +145,26 @@ if (first() | duped())
         }
 
         timer("Debug", 100)
+
+        #[
+            Lock the E2, so that it can't be deleted or edited by anyone
+            except you.
+
+            This is not a security measure, as the E2 can still be
+            deleted or edited by you. It is only a convenience measure,
+            to prevent other users from accidentally or maliciously
+            deleting or editing the E2, which would cause RailDriver to
+            stop working.
+
+            You can still update the E2 by using the "Update" button in
+            the Remote Upload menu of the Expression 2 Tool Gun.
+        ]#
+        semLockE2()
+        assert(semE2IsLocked(), "Failed to lock E2.")
     }
 
     catch (Exception)
     {
-        # If an exception is thrown, unlock the E2.
-        # This is to prevent the E2 from being locked forever.
-        if (semE2IsLocked())
-        {
-            semUnlockE2()
-        }
-
-        #[
-            Notes from ZZ Cat:
-            I tried to unparent the E2 & re-weld it to the locomotive, but it didn't work.
-            I'm not sure why, but I'm not going to spend any more time on it.
-            If you know how to fix this, please let me know by opening either an issue or a pull request on GitHub.
-        ]#
-
         printColor(vec(255, 0, 0), "[RailDriver | Init | Error]", vec(255, 255, 255), ": " + Exception)
     }
 }


### PR DESCRIPTION
This PR only locks the E2 at the last movement, once everything else is successfully iniailized.

Also, when an exception is thrown, the E2 no longer attempts to unlock itself.
By rights, the E2 is already unlocked, so there should be no need to try to unlock the E2 here.

Fixes #21 