### PR TITLE
CLI: Add subcommands as an argument

### DIFF
--- a/lib/cli.txt
+++ b/lib/cli.txt
@@ -307,6 +307,9 @@ function table cliInit(CliPrefix:string)
     # Register the help command.
     Cli["Commands", table]["help", table] = table()
     Cli["Commands", table]["help", table]["Arguments", array] = array()
+    Cli["Commands", table]["update", table]["Arguments Count", number] = 0
+    Cli["Commands", table]["update", table]["Arguments List", array] = array()
+    Cli["Commands", table]["update", table]["Arguments List Count", number] = 0
     Cli["Commands", table]["help", table]["help", string] = "Displays this help message."
     Cli["Commands", table]["Flags", table]["help is updated", number] = 0
 
@@ -319,19 +322,29 @@ function table cliInit(CliPrefix:string)
     # Register the controls command.
     Cli["Commands", table]["controls", table] = table()
     Cli["Commands", table]["controls", table]["Arguments", array] = array()
+    Cli["Commands", table]["update", table]["Arguments Count", number] = 0
+    Cli["Commands", table]["update", table]["Arguments List", array] = array()
+    Cli["Commands", table]["update", table]["Arguments List Count", number] = 0
     Cli["Commands", table]["controls", table]["help", string] = "Displays a list of available player controls."
     Cli["Commands", table]["Flags", table]["controls is updated", number] = 0
 
     # Register the restart command.
     Cli["Commands", table]["restart", table] = table()
     Cli["Commands", table]["restart", table]["Arguments", array] = array()
+    Cli["Commands", table]["update", table]["Arguments Count", number] = 0
+    Cli["Commands", table]["update", table]["Arguments List", array] = array()
+    Cli["Commands", table]["update", table]["Arguments List Count", number] = 0
     Cli["Commands", table]["restart", table]["help", string] = "Restarts RailDriver."
     Cli["Commands", table]["Flags", table]["restart is updated", number] = 0
 
     # Register the update command with the argument "local".
     Cli["Commands", table]["update", table] = table()
     Cli["Commands", table]["update", table]["Arguments", array] = array()
-    Cli["Commands", table]["update", table]["Arguments", array]:pushString("local")
+    Cli["Commands", table]["update", table]["Arguments Count", number] = 1
+    Cli["Commands", table]["update", table]["Arguments List", array] = array()
+    Cli["Commands", table]["update", table]["Arguments List", array]:pushString("local")
+    Cli["Commands", table]["update", table]["Arguments List", array]:pushString("online")
+    Cli["Commands", table]["update", table]["Arguments List Count", number] = 2
     Cli["Commands", table]["update", table]["help", string] = "Uses Over-The-Air Updates to update RailDriver.\n  Arguments:\n    local - Updates RailDriver from your e2shared folder.\n    online - Coming soon."
     Cli["Commands", table]["Flags", table]["update is updated", number] = 0
 
@@ -618,6 +631,54 @@ function number cliProcessMessage(Cli:table, Message:string)
     }
 
     # Check if the command has any arguments.
+    if (Arguments:count() > 0 & Cli["Commands", table][Command, table]["Arguments Count", number] == 0)
+    {
+        # The command does not accept any arguments.
+        printColor(vec(255, 0, 0), "[RailDriver | cli | ERROR]", vec(255, 255, 255), ": Command '" + Command + "' does not accept any arguments.")
+        return 0
+    }
+
+    # Check if the command has the correct number of arguments.
+    if (Arguments:count() != Cli["Commands", table][Command, table]["Arguments Count", number])
+    {
+        # The command does not have the correct number of arguments.
+        printColor(vec(255, 0, 0), "[RailDriver | cli | ERROR]", vec(255, 255, 255), ": Command '" + Command + "' requires " + Cli["Commands", table][Command, table]["Arguments Count", number] + " argument(s).")
+        return 0
+    }
+
+    # Check if the arguments are valid.
+    local ArgumentIsValid = 0
+    local InvalidArgument = ""
+    for (I = 1, Arguments:count())
+    {
+        # Check if the argument is valid.
+        for(J = 1, Cli["Commands", table][Command, table]["Arguments List", array]:count())
+        {
+            if (Arguments[I, string] == Cli["Commands", table][Command, table]["Arguments List", array][J, string])
+            {
+                ArgumentIsValid = 1
+                break
+            }
+        }
+
+        # Get the invalid argument.
+        if (ArgumentIsValid == 0)
+        {
+            InvalidArgument = Arguments[I, string]
+            break
+        }
+    }
+
+    # Check if the argument is valid.
+    if (ArgumentIsValid == 0)
+    {
+        # The argument is not valid.
+        printColor(vec(255, 0, 0), "[RailDriver | cli | ERROR]", vec(255, 255, 255), ": Argument '" + InvalidArgument + "' is not valid for command '" + Command + "'.")
+        return 0
+    }
+
+    #[
+    # Check if the command has any arguments.
     if (Arguments:count() > 0 & Cli["Commands", table][Command, table]["Arguments", array]:count() == 0)
     {
         # The command does not accept any arguments.
@@ -644,6 +705,7 @@ function number cliProcessMessage(Cli:table, Message:string)
             return 0
         }
     }
+    ]#
 
     # Update the command.
     Cli["Commands", table][Command, table]["Arguments", array] = Arguments

--- a/lib/ota/online.txt
+++ b/lib/ota/online.txt
@@ -67,10 +67,16 @@ function string otaOnlineGetVersionURL(OtaOnline:table, OtaLocal:table)
 
     # Remove "e2shared/RailDriver/" from the Path.
     local PathPartsToReplace = "e2shared/RailDriver/"
-    Path = Path:sub(PathPartsToReplace:length(), Path:length())
+    Path = Path:sub(PathPartsToReplace:length() + 1, Path:length())
 
     # Compile the URL.
     URL = BaseURL + Username + "/" + Repository + "/" + Branch + "/" + Path + "/" + File
+
+    # This should compile as:
+    # https://raw.githubusercontent.com/ZZ-Cat/RailDriver/Over-The-Air-Updates_Part-2-of-2_Online/lib/ota/version.json
+    # 
+    # Compiled URL:
+    # https://raw.githubusercontent.com/ZZ-Cat/RailDriver/Over-The-Air-Updates_Part-2-of-2_Online/lib/ota/version.json
 
     # Return the URL.
     return URL

--- a/lib/ota/version.json
+++ b/lib/ota/version.json
@@ -24,7 +24,7 @@
                 "File":"cli.txt",
                 "Path":"e2shared/RailDriver/lib",
                 "Version":"0.1.0",
-                "Hash":"1369193795"
+                "Hash":"2097663203"
             },
             "Controls":
             {
@@ -50,7 +50,7 @@
                     "File":"online.txt",
                     "Path":"e2shared/RailDriver/lib/ota",
                     "Version":"0.1.0",
-                    "Hash":"63283595"
+                    "Hash":"2741946490"
                 }
             },
             "PIDF Controller":


### PR DESCRIPTION
Re-opened from #32, because I set the wrong branch for this PR to be merged into. Now, this PR will be merged into the correct branch.

Right-oh...

### What's new

This Pull Request enables RailDriver's CLI to use a list of subcommands as an argument.

IE things like ```.raildriver update local``` & ```.raildriver update online``` will now work as intended.