### PR TITLE
Version FIle Scanning Method 1

### DIFF
--- a/lib/ota/remote.txt
+++ b/lib/ota/remote.txt
@@ -32,7 +32,7 @@ function table otaOnlineInit()
 {
     local Ota = table()
 
-    Ota["Online Updates Branch", string] = "Version-File-Scanning-Method-1"
+    Ota["Online Updates Branch", string] = "Over-The-Air-Updates_Part-2-of-2_Online"
     Ota["Version File URL", string] = ""
     Ota["Clock ID", string] = "RailDriver OTA Online Clock"
     Ota["Clock Delay", number] = 0

--- a/lib/ota/remote.txt
+++ b/lib/ota/remote.txt
@@ -32,7 +32,7 @@ function table otaOnlineInit()
 {
     local Ota = table()
 
-    Ota["Online Updates Branch", string] = "Over-The-Air-Updates_Part-2-of-2_Online"
+    Ota["Online Updates Branch", string] = "Version-File-Scanning-Method-1"
     Ota["Version File URL", string] = ""
     Ota["Clock ID", string] = "RailDriver OTA Online Clock"
     Ota["Clock Delay", number] = 0

--- a/lib/ota/remote.txt
+++ b/lib/ota/remote.txt
@@ -357,7 +357,7 @@ function void otaOnlineReceiveResponseHandler(Ota:table)
                 I have reason to believe that the first way is the better way to go about this,
                 because it is more efficient & it is a more reliable way to catch errors.
                 However, right now, I am undecided on which way I need to go about this.
-                
+
                 I will need to do some testing to see which way is better.
                 I will create another branch off of this branch to test the first way.
                 Then, I will create another branch off of this branch to test the second way.


### PR DESCRIPTION
## Overview

This Pull Request is a part of an ongoing test to determine the best method to scan through the Version File in order to determine whether-or-not one or more of RailDriver's libraries need to be updated in-game.

I have two methods to test & compare:

- **Method 1** - This method compares the checksums of each file that is listed in the Online Version File with the checksums of each file in the Local Version File. If the checksums do not match, then the semantic version number of the library is compared. If the semantic version number of the library in the Online Version File is greater than the semantic version number of the library in the Local Version File, then the library is updated in-game.
- **Method 2** - This method compares the semantic version numbers of each library that is listed in the Online Version File with the semantic version numbers of each library in the Local Version File. If the semantic version number of the library in the Online Version File is greater than the semantic version number of the library in the Local Version File, then the checksum is compared. If the checksums do not match, then the library is updated in-game.

This Pull Request is for testing **Method 1**.

## Method 1

In this method, I can easily catch any errors that occur during the comparisons. For example, if the checksums between a file in the Local Version File does not match the checksum in the Online Version File, then I know that file has changed.
Then, I can compare the semantic version numbers of that file.
If the semantic version numbers of the local file is greater than the semantic version number of the online file, then I can check if the player is a developer. If the player is not a developer, I may want to throw an error message to the player.
If the player is a developer, then I may want to throw a warning message to the player to remind them to update the Online Version File on RailDriver's GitHub repository.

If the semantic version numbers of the local file is less than the semantic version numbers of the online file, then that file is downloaded & updated in-game.

If the semantic version numbers are equal, then this file will be skipped.

### Results from Method 1

To be determined.

## Method 2

In this method, deciding on whether-or-not a file needs to be updated in-game is a similar process to Method 1.
However, the semantic version numbers are compared first *before* the checksums.
This means that the semantic version numbers of each file need to be parsed from both the Local Version File & the Online Version File, in order to compare them.
This is a bit more complicated than Method 1 & may be more prone to errors. EG ```Tick Quota Exceeded```.
I also believe that this method may introduce more computational overhead than Method 1 because of the extra parsing that needs to be done. Thus, the reason for testing both methods. I want to a.) Be proven wrong; & b.) Determine which method is more efficient.

### Results from Method 2

To be determined.

## Conclusion

To be determined.
