### PR TITLE
PIDF Controller tuning & scaling

### DIFF
--- a/RailDriver-LTS.txt
+++ b/RailDriver-LTS.txt
@@ -41,7 +41,7 @@ if (first() | duped())
     local PIDItermDecayHysteresis = 1
 
     local PIDItermLimit = 90
-    local PIDOutputLimit = 100
+    local PIDOutputLimit = 150
 
     local SpeedometerFilterCutoffFrequency = 1
     local SpeedometerDeadband = 0.1

--- a/RailDriver-LTS.txt
+++ b/RailDriver-LTS.txt
@@ -40,7 +40,7 @@ if (first() | duped())
     local PIDItermDecayThreshold = 3.0 * 17.6
     local PIDItermDecayHysteresis = 1
 
-    local PIDItermLimit = 75000
+    local PIDItermLimit = 75
     local PIDOutputLimit = 75000
 
     local SpeedometerFilterCutoffFrequency = 1

--- a/RailDriver-LTS.txt
+++ b/RailDriver-LTS.txt
@@ -41,7 +41,7 @@ if (first() | duped())
     local PIDItermDecayHysteresis = 1
 
     local PIDItermLimit = 75
-    local PIDOutputLimit = 75000
+    local PIDOutputLimit = 100
 
     local SpeedometerFilterCutoffFrequency = 1
     local SpeedometerDeadband = 0.1

--- a/RailDriver-LTS.txt
+++ b/RailDriver-LTS.txt
@@ -40,7 +40,7 @@ if (first() | duped())
     local PIDItermDecayThreshold = 3.0 * 17.6
     local PIDItermDecayHysteresis = 1
 
-    local PIDItermLimit = 75
+    local PIDItermLimit = 90
     local PIDOutputLimit = 100
 
     local SpeedometerFilterCutoffFrequency = 1

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -124,8 +124,16 @@ function number pidSetItermLimits(S:table, Min, Max)
 
     else
     {
-        S["I-Term Limit Min", number] = Min
-        S["I-Term Limit Max", number] = Max
+        local E = entity():parent()
+        local BodyMass = 1
+
+        if (E:isValid() & E:isValidPhysics())
+        {
+            BodyMass = E:mass()
+        }
+
+        S["I-Term Limit Min", number] = Min * (BodyMass / 40)
+        S["I-Term Limit Max", number] = Max * (BodyMass / 40)
 
         if (S["Use I-Term Limit", number] != 0)
         {
@@ -145,8 +153,16 @@ function number pidSetOutputLimits(S:table, Floor, Ceiling)
 
     else
     {
-        S["CV Floor", number] = Floor
-        S["CV Ceiling", number] = Ceiling
+        local E = entity():parent()
+        local BodyMass = 1
+
+        if (E:isValid() & E:isValidPhysics())
+        {
+            BodyMass = E:mass()
+        }
+
+        S["CV Floor", number] = Floor * (BodyMass / 40)
+        S["CV Ceiling", number] = Ceiling * (BodyMass / 40)
 
         if (S["Mode", string] != "automatic")
         {


### PR DESCRIPTION
## Overview

This Pull Request contains tuning adjustments of RailDriver-LTS' control loop.

## What's new

- Locomotive body mass is now factored into the scaling of the Control Variable Output & the I-Term Limit.
- I-Term Limit has been adjusted to reflect the new scaling.
- Control Variable Output Limit has been increased by 25 units to ensure the Control Loop remains locked-in with a moderate load in-tow.

## Additional information

The adjustments made here were tuned & tested on the Flatgrass Construct & Northern Railroad server.
This addresses a situation where the Control Loop loses control of the entire train's speed, when the locomotive has a moderately sized load in-tow. Thus, causing a runaway.