### PR TITLE
D-Term improvements & refactor Proportional Modes

### DIFF
--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -194,7 +194,6 @@ if (RailDriverState == 1)
             pidSetItermDecay(PIDF, PIDItermDecayRate, PIDItermDecayThreshold, PIDItermDecayHysteresis)
             pidSetItermLimits(PIDF, -PIDItermLimit, PIDItermLimit)
             pidSetOutputLimits(PIDF, -PIDOutputLimit, PIDOutputLimit)
-            pidSetProportionalMode(PIDF, "Proportional on Measurement")
             pidSetMode(PIDF, "Automatic")
             runOnTick(1)
         }

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -186,7 +186,7 @@ if (RailDriverState == 1)
 
         # Initialize the PIDF controller.
         PIDF = pidCreateInstance()
-        if (PIDF:count() == 55)
+        if (PIDF:count() == 54)
         {
             # Set the initial PIDF Controller's parameters.
             pidSetPIDcoefficients(PIDF, PIDCoefficientKp, PIDCoefficientKi, PIDCoefficientKd)

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -81,7 +81,7 @@ if (RailDriverState == 1)
     local PIDCoefficientKd = 250
 
     local PIDItermDecayRate = 0.5
-    local PIDItermDecayThreshold = 15.0 * 17.6
+    local PIDItermDecayThreshold = 3.0 * 17.6
     local PIDItermDecayHysteresis = 1
 
     local PIDItermLimit = 75000

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -78,7 +78,7 @@ if (RailDriverState == 1)
 {
     local PIDCoefficientKp = 1020
     local PIDCoefficientKi = 850
-    local PIDCoefficientKd = 10
+    local PIDCoefficientKd = 250
 
     local PIDItermDecayRate = 0.5
     local PIDItermDecayThreshold = 15.0 * 17.6

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -81,7 +81,7 @@ if (RailDriverState == 1)
     local PIDCoefficientKd = 10
 
     local PIDItermDecayRate = 0.5
-    local PIDItermDecayThreshold = 3.0 * 17.6
+    local PIDItermDecayThreshold = 15.0 * 17.6
     local PIDItermDecayHysteresis = 1
 
     local PIDItermLimit = 75000

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -34,7 +34,7 @@ function table pidCreateInstance()
     S["Integral", number] = 0
     S["Derivative", number] = 0
     S["Feed Forward", number] = 0
-    S["Proportional Mode", number] = 0
+    S["Use Proportional on Error", number] = 1
     S["Direction", number] = 1
     S["Mode", number] = 1
 

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -161,12 +161,12 @@ function number pidSetOutputLimits(S:table, Floor, Ceiling)
 
 function number pidSetProportionalMode(S:table, PMode:string)
 {
-    PMode:lower()
+    PMode = PMode:lower()
     switch (PMode)
     {
         case "error",
         case "proportional on error",
-            S["Proportional Mode", number] = 0
+            S["Use Proportional on Error", number] = 1
             return 1
         break
 
@@ -174,7 +174,7 @@ function number pidSetProportionalMode(S:table, PMode:string)
         case "measurement",
         case "proportional on measurement",
         case "proportional on measure",
-            S["Proportional Mode", number] = 1
+            S["Use Proportional on Error", number] = 0
             return 1
         break
 
@@ -187,7 +187,7 @@ function number pidSetProportionalMode(S:table, PMode:string)
 function number pidSetCoefficients(S:table, Gains:string, Value)
 {
     local MillisToSeconds = S["Sample Time", number] / 1000
-    Gains:lower()
+    Gains = Gains:lower()
     switch (Gains)
     {
         case "kp",
@@ -348,7 +348,7 @@ function number pidInitialize(S:table)
 
 function number pidSetMode(S:table, M:string)
 {
-    M:lower()
+    M = M:lower()
     switch(M)
     {
         case "manual",
@@ -376,7 +376,7 @@ function void pidSetFeedforward(S:table, FFname:string, Value)
 {
     local FeedForwardSum = 0
 
-    FFname:lower()
+    FFname = FFname:lower()
     switch (FFname)
     {
         case "acceleration",

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -53,7 +53,7 @@ function table pidCreateInstance()
     S["I-Term Decay Hysteresis", number] = (1/100)*S["I-Term Decay Threshold", number]
 
     # Default I-Term Relax properties:
-    S["Use I-Term Relax", number] = 0
+    S["Use I-Term Relax", number] = 1
     S["I-Term Relax Threshold", number] = 40.0
     S["I-Term Relax Type", string] = "Set Point"
 
@@ -497,8 +497,14 @@ function number pidCalculate(S:table)
         # Calculate I Term Relax
         if (S["Use I-Term Relax", number] != 0)
         {
-            ITermError = pidSetItermRelax(S, S["I-Term", number], ITermError, S["Process Variable", number], S["Set Point", number])
-            Error = ITermError
+            # Calculate I Term Error Rate.
+            local ItermErrorRate = (ITermError - S["Last Error", number]) / TimeDelta
+
+            # Calculate I Term Relax.
+            ItermErrorRate = pidSetItermRelax(S, S["I-Term", number], ItermErrorRate, S["Process Variable", number], S["Set Point", number])
+
+            # Calculate I Term.
+            S["I-Term", number] = S["I-Term", number] + (ItermErrorRate * TimeDelta)
         }
 
         # Calculate I-Term.
@@ -594,6 +600,7 @@ function number pidCalculate(S:table)
         S["Control Variable", number] = S["CV Sum", number]
 
         # Store a couple of variables for use in the next execution.
+        S["Last Error", number] = Error
         S["Last I-Term", number] = S["I-Term", number]
         S["Last Process Variable", number] = S["Process Variable", number]
         S["Last Time", number] = Now

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -531,12 +531,58 @@ function number pidCalculate(S:table)
         local PVdelta = S["Process Variable", number] - S["Last Process Variable", number]
         S["I-Term", number] = S["I-Term", number] + (S["Internal I Gain", number] * ITermError)
 
-        # Calculate Proportional on Measurement, if specified.
-        if (S["Proportional Mode", number] == 1)
-        {
-            S["P-Term", number] = S["Internal P Gain", number] * PVdelta
-            S["I-Term", number] = S["I-Term", number] - S["P-Term", number]
-        }
+        #[
+            Notes from ZZ Cat:
+            RailDriver's PID controller is a bit different from most other PID controllers.
+            First off, RailDriver's PID controller is a PIDF controller, which means that it has a Feedforward component
+            to supplement the rest of the controller.
+            The Feedforward component is a sum of the following:
+                > Throttle Position - This is the throttle lever position.
+                > Brake Position - This is the brake lever position.
+                > Hill Climb & Hill Descent - This is the hill climb & hill descent components.
+                    It is based on the current speed of the locomotive, the current gradient of the track, & the current
+                    direction of travel.
+                    The hill climb & hill descent components are only active when the locomotive is moving & the gradient is
+                    greater than 0.5%.
+                > Cornering - This is the cornering component.
+                    It is based on the current speed of the locomotive & the locomotive's rate of turn.
+                    The cornering component is only active when the locomotive is moving
+                    & the rate of turn is greater than 0.5°/s.
+                > Acceleration - This is the acceleration component.
+                    It is based on the locomotive's rate of acceleration.
+                    The acceleration component is only active when the locomotive is moving & the rate of acceleration is
+                    greater than 0.5 m/s².
+            Each of these components are multiplied by their respective gain values & then summed together, & then multiplied
+            by a final gain value. The final gain value is a percentage of the total output of the PIDF controller - IE the
+            control variable.
+
+            RailDriver's PID controller has two methods of calculating the P-Term.
+            The first method is the traditional method, which is based on the error between the set point & the
+            process variable. This is called Proportional on Error.
+            The second method is based on the process variable delta & the I-Term. This is called Proportional on
+            Measurement.
+            Proportional on Error reacts faster to changes in the process variable, but it is more susceptible to
+            oscillation. Thus, it is less accurate & less stable.
+            Proportional on Measurement reacts slower to changes in the process variable, but it is less susceptible to
+            oscillation. Thus, it is more accurate & stable.
+            RailDriver's PID controller uses a weighted average of the two methods to calculate the P-Term.
+            The weighting is based on the I-Term & the I-Term's rate of change. Proportional on Error is used when the
+            I-Term is high & the I-Term's rate of change is high. Proportional on Measurement is used when the I-Term is
+            low & the I-Term's rate of change is low.
+
+            RailDriver's PID controller has an I-Term decay.
+            The I-Term decay is used to gradually reduce the I-Term to zero when the locomotive is slowing down to a stop.
+            This prevents the locomotive from overshooting its target speed when it is slowing down to a stop.
+            The I-Term decay is based on the I-Term & the I-Term decay rate. The I-Term decay is only active when the
+            set point is zero & the process variable is less than the I-Term decay threshold.
+
+            RailDriver's PID controller has a slew rate limiter.
+            The slew rate limiter is used to limit the rate of change of the control variable.
+            The slew rate limiter is based on the control variable delta & the time delta.
+            This is to help prevent the locomotive from jerking around & to help control the locomotive's acceleration &
+            deceleration. The slew rate limiter is only active when the locomotive is moving & the control variable delta is
+            greater than 0.5%.
+        ]#
 
         # Calculate & apply I-Term Limit.
         # This limits the buildup of Integral, to help stave off windup.

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -548,9 +548,8 @@ function number pidCalculate(S:table)
         # Calculate D-Term.
         S["D-Term", number] = S["Internal D Gain", number] * (PVdelta / TimeDelta)
 
-        # Apply feedforward to the Control Variable Summing Bus.
-        # NB: Feedforward is calculated elsewhere.
-        S["CV Sum", number] = S["CV Sum", number] + S["FF Sum", number]
+        # Calculate Control Variable.
+        S["CV Sum", number] = S["P-Term", number] + S["I-Term", number] + S["D-Term", number] + S["FF Sum", number]
 
         # Apply a limit to the Control Variable.
         S["CV Sum", number] = clamp(S["CV Sum", number], S["CV Floor", number], S["CV Ceiling", number])

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -529,7 +529,7 @@ function number pidCalculate(S:table)
 
         # Calculate I-Term.
         local PVdelta = S["Process Variable", number] - S["Last Process Variable", number]
-        S["I-Term", number] = S["I-Term", number] + (S["Internal I Gain", number] * Error)
+        S["I-Term", number] = S["I-Term", number] + (S["Internal I Gain", number] * ITermError)
 
         # Calculate Proportional on Measurement, if specified.
         if (S["Proportional Mode", number] == 1)

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -545,21 +545,8 @@ function number pidCalculate(S:table)
             S["I-Term", number] = clamp(S["I-Term", number], S["I-Term Limit Min", number], S["I-Term Limit Max", number])
         }
 
-        # Calculate Proportional on Error, if specified.
-        if (S["Proportional Mode", number] == 0)
-        {
-            S["P-Term", number] = S["Internal P Gain", number] * Error
-            S["CV Sum", number] = S["P-Term", number]
-        }
-
-        else
-        {
-            S["CV Sum", number] = 0
-        }
-
         # Calculate D-Term.
-        S["D-Term", number] = S["I-Term", number] - S["Internal D Gain", number] * PVdelta
-        S["CV Sum", number] = S["CV Sum", number] + S["D-Term", number]
+        S["D-Term", number] = S["Internal D Gain", number] * (PVdelta / TimeDelta)
 
         # Apply feedforward to the Control Variable Summing Bus.
         # NB: Feedforward is calculated elsewhere.

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -27,7 +27,7 @@ function table pidCreateInstance()
     S:clear()
 
     # Default properties:
-    S["Sample Time", number] = ticksToMillis(1)
+    S["Sample Time", number] = ticksToMillis(10)
     S["Range", number] = 75000
     S["Scale", number] = 1
     S["Proportional", number] = 0

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -34,7 +34,6 @@ function table pidCreateInstance()
     S["Integral", number] = 0
     S["Derivative", number] = 0
     S["Feed Forward", number] = 0
-    S["Use Proportional on Error", number] = 1
     S["Direction", number] = 1
     S["Mode", number] = 1
 
@@ -156,31 +155,6 @@ function number pidSetOutputLimits(S:table, Floor, Ceiling)
         S["CV Sum", number] = clamp(S["CV Sum", number], Floor, Ceiling)
         S["Control Variable", number] = S["CV Sum", number]
         return 1
-    }
-}
-
-function number pidSetProportionalMode(S:table, PMode:string)
-{
-    PMode = PMode:lower()
-    switch (PMode)
-    {
-        case "error",
-        case "proportional on error",
-            S["Use Proportional on Error", number] = 1
-            return 1
-        break
-
-        case "measure",
-        case "measurement",
-        case "proportional on measurement",
-        case "proportional on measure",
-            S["Use Proportional on Error", number] = 0
-            return 1
-        break
-
-        default,
-            return 0
-        break
     }
 }
 
@@ -584,6 +558,24 @@ function number pidCalculate(S:table)
             greater than 0.5%.
         ]#
 
+        # Calculate the I-Term's rate of change.
+        local ITermDelta = S["I-Term", number] - S["Last I-Term", number]
+
+        # Calculate the Proportional on Error component.
+        local PTermError = S["Internal P Gain", number] * Error
+
+        # Calculate the Proportional on Measurement component.
+        local PTermMeasurement = S["Internal P Gain", number] * PVdelta
+
+        # Use a weighted average of the two methods to calculate the P-Term using the I-Term & the I-Term's rate of change.
+        # The weighting is based on the I-Term & the I-Term's rate of change.
+        # Proportional on Error is used when the I-Term is high & the I-Term's rate of change is high.
+        # Proportional on Measurement is used when the I-Term is low & the I-Term's rate of change is low.
+        local ITermWeightPonE = abs((S["I-Term", number] / S["I-Term Limit Max", number]) * (ITermDelta / S["I-Term Limit Max", number]))
+        local ITermWeightPonM = 1 - ITermWeightPonE
+        S["P-Term", number] = (PTermError * ITermWeightPonE) + (PTermMeasurement * ITermWeightPonM)
+        S["I-Term", number] = S["I-Term", number] - (PTermMeasurement * ITermWeightPonM)
+
         # Calculate & apply I-Term Limit.
         # This limits the buildup of Integral, to help stave off windup.
         if (S["Use I-Term Limit", number] != 0)
@@ -602,6 +594,7 @@ function number pidCalculate(S:table)
         S["Control Variable", number] = S["CV Sum", number]
 
         # Store a couple of variables for use in the next execution.
+        S["Last I-Term", number] = S["I-Term", number]
         S["Last Process Variable", number] = S["Process Variable", number]
         S["Last Time", number] = Now
 

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -147,7 +147,7 @@ function array semFindTrucks()
 {
     local E = entity()
     local P = E:parent()
-    local CE = P:getConnectedEntities("axis")
+    local CE = P:getConnectedEntities(array("AdvBallsocket", "axis"))
 
     if (!CE[1, entity] | !CE[1, entity]:isValid())
     {

--- a/lib/timers.txt
+++ b/lib/timers.txt
@@ -22,7 +22,7 @@
 
 function number micros()
 {
-    return curtime() * 1000000
+    return realtime() * 1000000
 }
 
 function number millis()


### PR DESCRIPTION
## Overview

This Pull Request fixes issue #40.
While I was here, I decied to take the time to clean some stuff up & refactor the Proportional Modes in the control loop, as well.

## What's new

- D-Term now has correct functionality & provides excellent dampening.
- Increased the sampling time of the control loop to 10 ticks.
- Proportional Modes refactor.
  - Removed the option to manually switch between Proportional on Error & Proportional on Measurement.
  - A weighted average is now used to dynamically switch between Proportional on Error & Proportional on Measurement.

## Proportional on Error vs Proportional on Measurement

Okay, I am going to put on my Control Theory hat for a hot minute here, if you will indulge me.
PID controllers as we know them have three terms: Proportional, Integral & Derivative.
Simply put: Proportional is "How fast am I going to react to a disturbance?"; Integral is "How strongly am I going to correct from this disturbance & how strong am I going to hold my current set target?"; & Derivative is "How resistant do I want to be to any changes?"

All three terms are based on a difference between the Set Point (IE how fast you want your locomotive to go) & a measured input value called the Process Variable. (In RailDriver's case, the Process Variable here is how fast the locomotive is *actually* traveling).
That difference is called the Error.

Proportional on Error, as the name implies, means that the control loop will initially act on the Error between the Set Point & the Process Variable. This is how traditional PID controllers work. Two examples of such come to mind here: BetaFlight & RotorFlight.
Their control loops use Proportional on Error.
The benefit here is Proportional on Error is incredibly fast acting to any disturbances, whether its changes to the Set Point or something else has caused the thing being controlled to stray from where it's supposed to be.
This comes with the drawback of Proportional on Error being more prone to oscillations & overshooting, even when the P-Term's respective gain is correctly tuned.
So, you trade accuracy off for speed. That's okay for situations like BetaFlight & RotorFlight, because those are controlling aerobatics aircraft (quads & helicopters, respectively). Trains on the other hand, that's a different story.

Thus... enter Proportional on Measurement.
Rather than acting on the Error from the Process Variable & Set Point, PonM is based on the control loop's Integral term.
A difference is taken between the current Process Variable & the previous Process Variable & the Proportional term is applied to that instead, & then subtracted from the Integral term.
This has the benefit of being more accurate, with the tradeoff of it being slow to act on disturbances, granted the Integral takes a long time to react to disturbances.

Up until now, RailDriver has had its control loop on Proportional on Measurement by default.
I did this because I wanted to have RailDriver operate as smoothly as I could possibly get it. This was at the sacrifice of a portion of the control loop's holding power, when you're climbing hills & such.

## "Why can't I have both?"

"Both?"
"Both!"
"Both is good."

For the longest time, I was undecided on whether to use one mode in favor of the other, but I kept seeing scenarios where RailDriver favored PonM over PonE & vice versa, & I could never make up my mind on it.
So, I came up with a method to dynamically switch between them on the fly, as & when RailDriver needed it.

Now, Proportional on Error is favored when RailDriver is accelerating your train to your set speed. Once it gets there, it will use Proportional on Measurement to precisely hold it there. The way I have done this is not as simple as flipping a single value from 1 to 0 & vice versa, no-no-noooo.
I gave this a weighted average based on the control loop's Integral term & the Integral term's rate of change.
That way, the control loop will dynamically use Proportional on Error when it is needed, & dynamically  use Proportional on Measurement when that is needed as well, & a blend of the two somewhere in between.

## The result?

Much smoother acceleration & transitions to set speeds with minimal overshoot.

## Additional

Another minor bug that I spotted while working on this is SEM raises a false error, when the locomotive's trucks are AdvBallsocket constrained. This PR also fixes that. You're welcome. =^/.~=