### PR TITLE
RailDriver: Hill Climb & Descent Feedforward

### DIFF
--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -22,10 +22,11 @@
 @persist [Direction Throttle Brake EmergencyBrake]:number
 @persist [OTALocal CLI PlayerControls ThrottleMap BrakeMap]:table TrainDriver:entity
 @persist PIDF:table
+@persist HillClimbDescentData:array
 @persist EmBrakeState EmBrakeThisSpeed EmBrakeLastSpeed EmBrakeObserverTickInterval EmBrakePCFaultTimeoutSet
 @persist Speed SpeedAbs SpeedMPH
 @persist DupeTickInterval DupeIsLoading DupeIsFinished RailDriverIsReady RailDriverIsInitialized RailDriverState
-@outputs Debugger:table DbgAcceleration:vector [DbgAngulerVelocity DbgOrientation]:angle
+@outputs Debugger:table DbgAcceleration:vector [DbgAngulerVelocity DbgOrientation]:angle DbgGradient DbgHillClimbDescentFF
 @strict
 
 if (duped())
@@ -81,6 +82,8 @@ if (RailDriverState == 1)
     local PIDCoefficientKd = 250
 
     local PIDCoefficientFFprimary = 100
+    local PIDCoefficientFFhillclimb = 2000
+
     local PIDItermDecayRate = 0.5
     local PIDItermDecayThreshold = 3.0 * 17.6
     local PIDItermDecayHysteresis = 1
@@ -200,12 +203,14 @@ if (RailDriverState == 1)
 
         # Initialize the PIDF controller.
         PIDF = pidCreateInstance()
-        if (PIDF:count() == 54)
+        if (PIDF:count() == 57)
         {
             # Set the initial PIDF Controller's parameters.
+            HillClimbDescentData = array(0, 0, 0)
             pidSetPIDcoefficients(PIDF, PIDCoefficientKp, PIDCoefficientKi, PIDCoefficientKd)
             pidSetFFcoefficients(PIDF, PIDCoefficientFFprimary)
             pidSetFFcoefficients(PIDF, 0, 0, 0, 0, 0)
+            pidSetCoefficients(PIDF, "hill climb/descent feedforward", PIDCoefficientFFhillclimb)
             pidSetItermDecay(PIDF, PIDItermDecayRate, PIDItermDecayThreshold, PIDItermDecayHysteresis)
             pidSetItermLimits(PIDF, -PIDItermLimit, PIDItermLimit)
             pidSetOutputLimits(PIDF, -PIDOutputLimit, PIDOutputLimit)
@@ -491,12 +496,22 @@ elseif (RailDriverState == 2)
             DbgAcceleration = Acceleration
             DbgAngularVelocity = AngularVelocity
             DbgOrientation = Orientation
+
+            # Calculate the track's grade in percent from the pitch of the locomotive's orientation.
+            local Gradient = 0
+            Gradient = tan(Orientation:pitch()) * 100
+
+            # Debug.
+            DbgGradient = round(Gradient, 4)
+
+            # Set the Gradient input to the Hill Climb/Descent Feedforward data.
+            HillClimbDescentData[2, number] = Gradient
         }
 
         catch(Exception)
         {
             ndofStopSensorLoop(NDOF)
-            printColor(vec(255, 0, 0), "[RailDriver | NDOF | Error]", vec(255, 255, 255), Exception)
+            printColor(vec(255, 0, 0), "[RailDriver | NDOF | Error]", vec(255, 255, 255), ": " + Exception)
         }
     }
 
@@ -519,6 +534,9 @@ elseif (RailDriverState == 2)
             # This is the measured speed of the locomotive.
             pidSetProcessVariable(PIDF, SpeedAbs)
 
+            # Set the Speed input to the Hill Climb/Descent Feedforward data.
+            HillClimbDescentData[1, number] = SpeedAbs
+
             # Convert speed from Garry's Mod units to miles per hour.
             SpeedMPH = round(toUnit("mph", SpeedAbs) * 4 / 3)
         }
@@ -533,6 +551,12 @@ elseif (RailDriverState == 2)
     {
         try
         {
+            # Set the Hill Climb/Descent Feedforward input to the PIDF controller.
+            pidSetHillClimbDescentFeedforward(PIDF, HillClimbDescentData)
+
+            # Debug.
+            DbgHillClimbDescentFF = pidGetFFhillClimbDescent(PIDF)
+
             # Calculate the PIDF controller's output.
             pidCalculate(PIDF) # <--- This is where the magick happens. =^/,..,^=
 
@@ -618,6 +642,9 @@ elseif (RailDriverState == 2)
                     # Set the PIDF controller's direction.
                     pidSetDirection(PIDF, Direction)
 
+                    # Set the Direction input to the Hill Climb/Descent Feedforward data.
+                    HillClimbDescentData[3, number] = Direction
+
                     # Clear the Direction is Updated flag.
                     playerControlsClearDirectionIsUpdated(PlayerControls)
                 }
@@ -634,6 +661,9 @@ elseif (RailDriverState == 2)
                     # Set the PIDF controller's setpoint.
                     pidSetFeedforward(PIDF, "Throttle", VelocitySetpointGM)
                     pidSetSetPoint(PIDF, VelocitySetpointGM)
+
+                    # Set the Velocity Setpoint input to the Hill Climb/Descent Feedforward data.
+                    HillClimbDescentData[4, number] = VelocitySetpointGM
 
                     # Clear the Throttle is Updated flag.
                     playerControlsClearThrottleIsUpdated(PlayerControls)

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -202,22 +202,30 @@ if (RailDriverState == 1)
         Brake = 1
         EmergencyBrake = 0
 
-        # Initialize the PIDF controller.
+        # Initialize the PIDF Controller.
         PIDF = pidCreateInstance()
         if (PIDF:count() == 57)
         {
-            # Set the initial PIDF Controller's parameters.
             HillClimbDescentData = array(0, 0, 0)
-            pidSetPIDcoefficients(PIDF, PIDCoefficientKp, PIDCoefficientKi, PIDCoefficientKd)
-            pidSetFFcoefficients(PIDF, PIDCoefficientFFprimary)
-            pidSetFFcoefficients(PIDF, 0, 0, 0, 0, 0)
-            pidSetCoefficients(PIDF, "hill climb/descent feedforward", PIDCoefficientFFhillclimb)
-            pidSetFeedforwardLimits(PIDF, -PIDFeedforwardLimit, PIDFeedforwardLimit)
-            pidSetItermDecay(PIDF, PIDItermDecayRate, PIDItermDecayThreshold, PIDItermDecayHysteresis)
-            pidSetItermLimits(PIDF, -PIDItermLimit, PIDItermLimit)
-            pidSetOutputLimits(PIDF, -PIDOutputLimit, PIDOutputLimit)
+
+            # Set the PIDF Controller's proportional, integral, & derivative coefficients.
+            assert(pidSetCoefficient(PIDF, "proportional", PIDCoefficientKp) == PIDCoefficientKp, "Failed to set the PIDF Controller's proportional coefficient.")
+            assert(pidSetCoefficient(PIDF, "integral", PIDCoefficientKi) == PIDCoefficientKi, "Failed to set the PIDF Controller's integral coefficient.")
+            assert(pidSetCoefficient(PIDF, "derivative", PIDCoefficientKd) == PIDCoefficientKd, "Failed to set the PIDF Controller's derivative coefficient.")
+
+            # Set the PIDF Controller's feedforward coefficients.
+            assert(pidSetCoefficient(PIDF, "primary feedforward", PIDCoefficientFFprimary) == PIDCoefficientFFprimary, "Failed to set the PIDF Controller's primary feedforward coefficient.")
+            assert(pidSetCoefficient(PIDF, "hill climb/descent feedforward", PIDCoefficientFFhillclimb) == PIDCoefficientFFhillclimb, "Failed to set the PIDF Controller's hill climb/descent feedforward coefficient.")
+
+            # Set the PIDF Controller's limits.
+            assert(pidSetFeedforwardLimits(PIDF, -PIDFeedforwardLimit, PIDFeedforwardLimit) == 1, "Failed to set the PIDF Controller's feedforward limits.")
+            assert(pidSetItermDecay(PIDF, PIDItermDecayRate, PIDItermDecayThreshold, PIDItermDecayHysteresis) == 1, "Failed to set the PIDF Controller's integral decay.")
+            assert(pidSetItermLimits(PIDF, -PIDItermLimit, PIDItermLimit) == 1, "Failed to set the PIDF Controller's integral limits.")
+            assert(pidSetOutputLimits(PIDF, -PIDOutputLimit, PIDOutputLimit) == 1, "Failed to set the PIDF Controller's output limits.")
+
+            # Set the PIDF Controller's mode.
             pidSetDirection(PIDF, Direction)
-            pidSetMode(PIDF, "Automatic")
+            assert(pidSetMode(PIDF, "Automatic") == 1, "Failed to set the PIDF Controller's mode.")
             runOnTick(1)
         }
 

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -80,6 +80,7 @@ if (RailDriverState == 1)
     local PIDCoefficientKi = 850
     local PIDCoefficientKd = 250
 
+    local PIDCoefficientFFprimary = 100
     local PIDItermDecayRate = 0.5
     local PIDItermDecayThreshold = 3.0 * 17.6
     local PIDItermDecayHysteresis = 1
@@ -203,6 +204,7 @@ if (RailDriverState == 1)
         {
             # Set the initial PIDF Controller's parameters.
             pidSetPIDcoefficients(PIDF, PIDCoefficientKp, PIDCoefficientKi, PIDCoefficientKd)
+            pidSetFFcoefficients(PIDF, PIDCoefficientFFprimary)
             pidSetFFcoefficients(PIDF, 0, 0, 0, 0, 0)
             pidSetItermDecay(PIDF, PIDItermDecayRate, PIDItermDecayThreshold, PIDItermDecayHysteresis)
             pidSetItermLimits(PIDF, -PIDItermLimit, PIDItermLimit)

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -89,7 +89,7 @@ if (RailDriverState == 1)
     local PIDItermDecayHysteresis = 1
 
     local PIDFeedforwardLimit = 20000
-    local PIDItermLimit = 75000
+    local PIDItermLimit = 15000
     local PIDOutputLimit = 75000
 
     local SpeedometerFilterCutoffFrequency = 1

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -207,6 +207,7 @@ if (RailDriverState == 1)
             pidSetItermDecay(PIDF, PIDItermDecayRate, PIDItermDecayThreshold, PIDItermDecayHysteresis)
             pidSetItermLimits(PIDF, -PIDItermLimit, PIDItermLimit)
             pidSetOutputLimits(PIDF, -PIDOutputLimit, PIDOutputLimit)
+            pidSetDirection(PIDF, Direction)
             pidSetMode(PIDF, "Automatic")
             runOnTick(1)
         }
@@ -611,6 +612,9 @@ elseif (RailDriverState == 2)
                 if (playerControlsDirectionIsUpdated(PlayerControls))
                 {
                     Direction = playerControlsGetDirection(PlayerControls)
+
+                    # Set the PIDF controller's direction.
+                    pidSetDirection(PIDF, Direction)
 
                     # Clear the Direction is Updated flag.
                     playerControlsClearDirectionIsUpdated(PlayerControls)

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -792,6 +792,9 @@ elseif (RailDriverState == 2)
                 pidSetFeedforward(PIDF, "Throttle", 0)
                 pidSetSetPoint(PIDF, 0)
 
+                # Set the Velocity Setpoint input to the Hill Climb/Descent Feedforward data.
+                HillClimbDescentData[4, number] = 0
+
                 # Set the Emergency Brake state to 2.
                 EmBrakeState = 2
 

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -88,6 +88,7 @@ if (RailDriverState == 1)
     local PIDItermDecayThreshold = 3.0 * 17.6
     local PIDItermDecayHysteresis = 1
 
+    local PIDFeedforwardLimit = 75000
     local PIDItermLimit = 75000
     local PIDOutputLimit = 75000
 
@@ -211,6 +212,7 @@ if (RailDriverState == 1)
             pidSetFFcoefficients(PIDF, PIDCoefficientFFprimary)
             pidSetFFcoefficients(PIDF, 0, 0, 0, 0, 0)
             pidSetCoefficients(PIDF, "hill climb/descent feedforward", PIDCoefficientFFhillclimb)
+            pidSetFeedforwardLimits(PIDF, -PIDFeedforwardLimit, PIDFeedforwardLimit)
             pidSetItermDecay(PIDF, PIDItermDecayRate, PIDItermDecayThreshold, PIDItermDecayHysteresis)
             pidSetItermLimits(PIDF, -PIDItermLimit, PIDItermLimit)
             pidSetOutputLimits(PIDF, -PIDOutputLimit, PIDOutputLimit)

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -18,14 +18,14 @@
 
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
-@persist Trucks:array Speedo:table
+@persist Trucks:array Speedo:table NDOF:table
 @persist [Direction Throttle Brake EmergencyBrake]:number
 @persist [OTALocal CLI PlayerControls ThrottleMap BrakeMap]:table TrainDriver:entity
 @persist PIDF:table
 @persist EmBrakeState EmBrakeThisSpeed EmBrakeLastSpeed EmBrakeObserverTickInterval EmBrakePCFaultTimeoutSet
 @persist Speed SpeedAbs SpeedMPH
 @persist DupeTickInterval DupeIsLoading DupeIsFinished RailDriverIsReady RailDriverIsInitialized RailDriverState
-@outputs Debugger:table
+@outputs Debugger:table DbgAcceleration:vector [DbgAngulerVelocity DbgOrientation]:angle
 @strict
 
 if (duped())
@@ -94,6 +94,7 @@ if (RailDriverState == 1)
     {
         #include "e2shared/RailDriver/lib/ota/local"
         #include "e2shared/RailDriver/lib/smartEntityManagement"
+        #include "e2shared/RailDriver/lib/sensors/ndof"
         #include "e2shared/RailDriver/lib/sensors/speedometer"
         #include "e2shared/RailDriver/lib/controls/playerControls"
         #include "e2shared/RailDriver/lib/cli"
@@ -146,6 +147,18 @@ if (RailDriverState == 1)
         else
         {
             error("RailDriver: Failed to initialize Speedometer.")
+        }
+
+        # Initialize NDOF Sensor.
+        NDOF = ndofInit(Trucks)
+        if (NDOF:count() > 0)
+        {
+            ndofStartSensorLoop(NDOF)
+        }
+
+        else
+        {
+            error("RailDriver: Failed to initialize NDOF Sensor.")
         }
 
         # Setup throttle and brake maps.
@@ -454,6 +467,33 @@ elseif (RailDriverState == 2)
         else
         {
             timer("Chat Print", 500)
+        }
+    }
+
+    if (clk(ndofGetClockId(NDOF)))
+    {
+        try
+        {
+            ndofSensorLoop(NDOF)
+
+            local SensorValues = ndofGetSensorValues(NDOF)
+
+            assert(SensorValues:count() == 3, "Invalid sensor values.")
+
+            local Acceleration = SensorValues[1, vector]
+            local AngularVelocity = SensorValues[2, angle]
+            local Orientation = SensorValues[3, angle]
+
+            # Debug.
+            DbgAcceleration = Acceleration
+            DbgAngularVelocity = AngularVelocity
+            DbgOrientation = Orientation
+        }
+
+        catch(Exception)
+        {
+            ndofStopSensorLoop(NDOF)
+            printColor(vec(255, 0, 0), "[RailDriver | NDOF | Error]", vec(255, 255, 255), Exception)
         }
     }
 

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -82,7 +82,7 @@ if (RailDriverState == 1)
     local PIDCoefficientKd = 250
 
     local PIDCoefficientFFprimary = 100
-    local PIDCoefficientFFhillclimb = 2000
+    local PIDCoefficientFFhillclimb = 5500
 
     local PIDItermDecayRate = 0.5
     local PIDItermDecayThreshold = 3.0 * 17.6

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -88,7 +88,7 @@ if (RailDriverState == 1)
     local PIDItermDecayThreshold = 3.0 * 17.6
     local PIDItermDecayHysteresis = 1
 
-    local PIDFeedforwardLimit = 75000
+    local PIDFeedforwardLimit = 20000
     local PIDItermLimit = 75000
     local PIDOutputLimit = 75000
 

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -217,15 +217,17 @@ if (RailDriverState == 1)
             assert(pidSetCoefficient(PIDF, "primary feedforward", PIDCoefficientFFprimary) == PIDCoefficientFFprimary, "Failed to set the PIDF Controller's primary feedforward coefficient.")
             assert(pidSetCoefficient(PIDF, "hill climb/descent feedforward", PIDCoefficientFFhillclimb) == PIDCoefficientFFhillclimb, "Failed to set the PIDF Controller's hill climb/descent feedforward coefficient.")
 
+            # Set the PIDF Controller's mode.
+            pidSetDirection(PIDF, Direction)
+            assert(pidSetMode(PIDF, "Automatic") == 1, "Failed to set the PIDF Controller's mode.")
+
             # Set the PIDF Controller's limits.
             assert(pidSetFeedforwardLimits(PIDF, -PIDFeedforwardLimit, PIDFeedforwardLimit) == 1, "Failed to set the PIDF Controller's feedforward limits.")
             assert(pidSetItermDecay(PIDF, PIDItermDecayRate, PIDItermDecayThreshold, PIDItermDecayHysteresis) == 1, "Failed to set the PIDF Controller's integral decay.")
             assert(pidSetItermLimits(PIDF, -PIDItermLimit, PIDItermLimit) == 1, "Failed to set the PIDF Controller's integral limits.")
             assert(pidSetOutputLimits(PIDF, -PIDOutputLimit, PIDOutputLimit) == 1, "Failed to set the PIDF Controller's output limits.")
 
-            # Set the PIDF Controller's mode.
-            pidSetDirection(PIDF, Direction)
-            assert(pidSetMode(PIDF, "Automatic") == 1, "Failed to set the PIDF Controller's mode.")
+            # Enable the PIDF Controller.
             runOnTick(1)
         }
 

--- a/lib/ota/version.json
+++ b/lib/ota/version.json
@@ -55,6 +55,13 @@
             },
             "Sensors":
             {
+                "9DoF":
+                {
+                    "File":"ndof.txt",
+                    "Path":"e2shared/RailDriver/lib/sensors",
+                    "Version":"0.1.0",
+                    "Hash":""
+                },
                 "Speedometer":
                 {
                     "File":"speedometer.txt",
@@ -102,6 +109,6 @@
                 }
             }
         },
-        "Hash":"4271356853"
+        "Hash":"2350320262"
     }
 }

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -63,7 +63,7 @@ function table pidCreateInstance()
     S["Control Variable", number] = 0
 
     # Feedforward Gains:
-    S["PIDF Coefficient Kf Master", number] = 100
+    S["PIDF Coefficient Kf Primary", number] = 100
     S["PIDF Coefficient Kf Acceleration", number] = 0
     S["PIDF Coefficient Kf Yaw Rate", number] = 0
     S["PIDF Coefficient Kf Pitch Angle", number] = 0
@@ -80,7 +80,7 @@ function table pidCreateInstance()
     S["Internal P Gain", number] = 0
     S["Internal I Gain", number] = 0
     S["Internal D Gain", number] = 0
-    S["Internal FF Master", number] = 1.0
+    S["Internal FF Primary", number] = 1.0
     S["Internal FF Accel", number] = 0
     S["Internal FF Yaw Rate", number] = 0
     S["Internal FF Pit Ang", number] = 0
@@ -182,7 +182,7 @@ function number pidSetOutputLimits(S:table, Floor, Ceiling)
     }
 }
 
-function number pidSetCoefficients(S:table, Gains:string, Value)
+function number pidSetCoefficient(S:table, Gains:string, Value)
 {
     local MillisToSeconds = S["Sample Time", number] / 1000
     Gains = Gains:lower()
@@ -213,11 +213,11 @@ function number pidSetCoefficients(S:table, Gains:string, Value)
         break
 
         case "kf",
-        case "pidf coefficient kf master",
-        case "master feedforward",
-            S["PIDF Coefficient Kf Master", number] = Value
-            S["Internal FF Master", number] = S["PIDF Coefficient Kf Master", number] / 100
-            return S["PIDF Coefficient Kf Master", number]
+        case "pidf coefficient kf primary",
+        case "primary feedforward",
+            S["PIDF Coefficient Kf Primary", number] = Value
+            S["Internal FF Primary", number] = S["PIDF Coefficient Kf Primary", number] / 100
+            return S["PIDF Coefficient Kf Primary", number]
         break
 
         case "kf accel",
@@ -275,17 +275,17 @@ function number pidSetCoefficients(S:table, Gains:string, Value)
 
 function number pidSetPIDcoefficients(S:table, PtermGain, ItermGain, DtermGain)
 {
-    if (pidSetCoefficients(S, "proportional", PtermGain) == 0)
+    if (pidSetCoefficient(S, "proportional", PtermGain) == 0)
     {
         return 0
     }
 
-    if (pidSetCoefficients(S, "integral", ItermGain) == 0)
+    if (pidSetCoefficient(S, "integral", ItermGain) == 0)
     {
         return 0
     }
 
-    if (pidSetCoefficients(S, "derivative", DtermGain) == 0)
+    if (pidSetCoefficient(S, "derivative", DtermGain) == 0)
     {
         return 0
     }
@@ -295,27 +295,27 @@ function number pidSetPIDcoefficients(S:table, PtermGain, ItermGain, DtermGain)
 
 function number pidSetFFcoefficients(S:table, FFaccel, FFyawRate, FFpitchAngle, FFthr, FFbrk)
 {
-    if (pidSetCoefficients(S, "acceleration feedforward", FFaccel) == 0)
+    if (pidSetCoefficient(S, "acceleration feedforward", FFaccel) == 0)
     {
         return 0
     }
 
-    if (pidSetCoefficients(S, "yaw rate feedforward", FFyawRate) == 0)
+    if (pidSetCoefficient(S, "yaw rate feedforward", FFyawRate) == 0)
     {
         return 0
     }
 
-    if (pidSetCoefficients(S, "pitch angle feedforward", FFpitchAngle) == 0)
+    if (pidSetCoefficient(S, "pitch angle feedforward", FFpitchAngle) == 0)
     {
         return 0
     }
 
-    if (pidSetCoefficients(S, "throttle feedforward", FFthr) == 0)
+    if (pidSetCoefficient(S, "throttle feedforward", FFthr) == 0)
     {
         return 0
     }
 
-    if (pidSetCoefficients(S, "brake feedforward", FFbrk) == 0)
+    if (pidSetCoefficient(S, "brake feedforward", FFbrk) == 0)
     {
         return 0
     }
@@ -325,7 +325,7 @@ function number pidSetFFcoefficients(S:table, FFaccel, FFyawRate, FFpitchAngle, 
 
 function number pidSetFFcoefficients(S:table, FFmaster)
 {
-    if (pidSetCoefficients(S, "master feedforward", FFmaster) == 0)
+    if (pidSetCoefficient(S, "primary feedforward", FFmaster) == 0)
     {
         return 0
     }
@@ -431,7 +431,7 @@ function void pidSetFeedforward(S:table, FFname:string, Value)
         FeedForwardSum = clamp(FeedForwardSum, S["Feedforward Limit Min", number], S["Feedforward Limit Max", number])
     }
 
-    S["FF Sum", number] = FeedForwardSum * S["Internal FF Master", number]
+    S["FF Sum", number] = FeedForwardSum * S["Internal FF Primary", number]
 
 }
 

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -171,7 +171,7 @@ function number pidSetOutputLimits(S:table, Floor, Ceiling)
         S["CV Floor", number] = Floor
         S["CV Ceiling", number] = Ceiling
 
-        if (S["Mode", string] != "automatic")
+        if (S["Mode", number] != 1)
         {
             return 0
         }

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -458,16 +458,8 @@ function void pidSetHillClimbDescentFeedforward(S:table, HillClimbDescentData:ar
             {
                 if (SetPoint == 0 & Speed >= 0)
                 {
-                    if (Speed == 0)
-                    {
-                        # Avoid division by zero.
-                        SetPointSpeedCompensation = 0
-                    }
-                    else
-                    {
-                        # Locomotive is stopping & going uphill.
-                        SetPointSpeedCompensation = 0.1 / Speed
-                    }
+                    # Locomotive is stopping & going uphill.
+                    SetPointSpeedCompensation = 0.001 * Speed
                 }
                 else
                 {
@@ -532,16 +524,8 @@ function void pidSetHillClimbDescentFeedforward(S:table, HillClimbDescentData:ar
             {
                 if (SetPoint == 0 & Speed >= 0)
                 {
-                    if (Speed == 0)
-                    {
-                        # Avoid division by zero.
-                        SetPointSpeedCompensation = 0
-                    }
-                    else
-                    {
-                        # Locomotive is stopping & going uphill.
-                        SetPointSpeedCompensation = 0.1 / Speed
-                    }
+                    # Locomotive is stopping & going uphill.
+                    SetPointSpeedCompensation = 0.001 * Speed
                 }
                 else
                 {

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -432,6 +432,12 @@ function void pidSetOutput(S:table, Value)
     S["Control Variable", number] = Value
 }
 
+# This function sets the direction of the control variable.
+function void pidSetDirection(S:table, Value)
+{
+    S["Direction", number] = Value
+}
+
 function number pidCalculate(S:table)
 {
     # PID Controller can have several operating modes.
@@ -597,7 +603,7 @@ function number pidCalculate(S:table)
 
         # Apply a limit to the Control Variable.
         S["CV Sum", number] = clamp(S["CV Sum", number], S["CV Floor", number], S["CV Ceiling", number])
-        S["Control Variable", number] = S["CV Sum", number]
+        S["Control Variable", number] = S["CV Sum", number] * S["Direction", number]
 
         # Store a couple of variables for use in the next execution.
         S["Last Error", number] = Error

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -292,6 +292,16 @@ function number pidSetFFcoefficients(S:table, FFaccel, FFyawRate, FFpitchAngle, 
     return 1
 }
 
+function number pidSetFFcoefficients(S:table, FFmaster)
+{
+    if (pidSetCoefficients(S, "master feedforward", FFmaster) == 0)
+    {
+        return 0
+    }
+
+    return 1
+}
+
 function number pidSetSampleTime(S:table, T)
 {
     if (T <= 0)

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -109,6 +109,27 @@ function table pidCreateInstance()
     return S
 }
 
+function number pidSetFeedforwardLimits(S:table, Min, Max)
+{
+    if (Min > Max)
+    {
+        return 0
+    }
+
+    else
+    {
+        S["Feedforward Limit Min", number] = Min
+        S["Feedforward Limit Max", number] = Max
+
+        if (S["Use Feedforward Limit", number] != 0)
+        {
+            S["FF Sum", number] = clamp(S["FF Sum", number], S["Feedforward Limit Min", number], S["Feedforward Limit Max", number])
+        }
+
+        return 1
+    }
+}
+
 function number pidSetItermDecay(S:table, Rate, Threshold, Hysteresis)
 {
     S["I-Term Decay Rate", number] = Rate

--- a/lib/pidf.txt
+++ b/lib/pidf.txt
@@ -67,6 +67,7 @@ function table pidCreateInstance()
     S["PIDF Coefficient Kf Acceleration", number] = 0
     S["PIDF Coefficient Kf Yaw Rate", number] = 0
     S["PIDF Coefficient Kf Pitch Angle", number] = 0
+    S["PIDF Coefficient Kf Hill Climb/Descent", number] = 0
     S["PIDF Coefficient Kf Throttle", number] = 0
     S["PIDF Coefficient Kf Brake", number] = 0
 
@@ -83,6 +84,7 @@ function table pidCreateInstance()
     S["Internal FF Accel", number] = 0
     S["Internal FF Yaw Rate", number] = 0
     S["Internal FF Pit Ang", number] = 0
+    S["Internal FF Hill Climb/Descent", number] = 0
     S["Internal FF Thr", number] = 0
     S["Internal FF Brk", number] = 0
 
@@ -97,6 +99,7 @@ function table pidCreateInstance()
     S["FF Accel", number] = 0
     S["FF Yaw Rate", number] = 0
     S["FF Pit Ang", number] = 0
+    S["FF Hill Climb/Descent", number] = 0
     S["FF Thr", number] = 0
     S["FF Brk", number] = 0
     S["FF Sum", number] = 0
@@ -219,6 +222,13 @@ function number pidSetCoefficients(S:table, Gains:string, Value)
             S["Internal FF Pitch Angle", number] = S["PIDF Coefficient Kf Pitch Angle", number] * S["Scale", number]
             return S["PIDF Coefficient Kf Pitch Angle", number]
         break
+
+        case "kf hill climb/descent",
+        case "pidf coefficient kf hill climb/descent",
+        case "hill climb/descent feedforward",
+            S["PIDF Coefficient Kf Hill Climb/Descent", number] = Value
+            S["Internal FF Hill Climb/Descent", number] = S["PIDF Coefficient Kf Hill Climb/Descent", number] * S["Scale", number]
+            return S["PIDF Coefficient Kf Hill Climb/Descent", number]
 
         case "kf thr",
         case "pidf coefficient kf throttle",
@@ -382,6 +392,10 @@ function void pidSetFeedforward(S:table, FFname:string, Value)
         case "yaw rate",
             S["FF Yaw Rate", number] = S["Internal FF Yaw Rate", number] * Value
         break
+
+        case "hill climb/descent",
+            S["FF Hill Climb/Descent", number] = S["Internal FF Hill Climb/Descent", number] * Value
+        break
     }
 
     FeedForwardSum += S["FF Accel", number]
@@ -389,6 +403,7 @@ function void pidSetFeedforward(S:table, FFname:string, Value)
     FeedForwardSum += S["FF Pit Ang", number]
     FeedForwardSum += S["FF Thr", number]
     FeedForwardSum += S["FF Yaw Rate", number]
+    FeedForwardSum += S["FF Hill Climb/Descent", number]
 
     if (S["Use Feedforward Limit", number] != 0)
     {
@@ -397,6 +412,137 @@ function void pidSetFeedforward(S:table, FFname:string, Value)
 
     S["FF Sum", number] = FeedForwardSum * S["Internal FF Master", number]
 
+}
+
+# This function sets the hill climb & descent feedforward.
+# This is based on the gradient of the track, the locomotive's speed, the locomotive's direction, & the set point.
+# The hill climb & descent feedforward is only applied when the gradient is greater than 0.5%.
+# This is to prevent the feedforward from being applied when the locomotive is on a flat section of track.
+function void pidSetHillClimbDescentFeedforward(S:table, HillClimbDescentData:array)
+{
+    local Speed = HillClimbDescentData[1, number]
+    local Gradient = HillClimbDescentData[2, number]
+    local Direction = HillClimbDescentData[3, number]
+    local SetPoint = HillClimbDescentData[4, number]
+    local HillClimbDescentFF = 0
+
+    if (abs(Gradient) > 0.5)
+    {
+        # First off, calculate a value using the set point & the locomotive's speed.
+        # This value is used to scale the hill climb & descent feedforward to the locomotive's speed.
+        local SetPointSpeedCompensation = 1
+        if (Gradient > 0)
+        {
+            if (Direction == 1)
+            {
+                if (SetPoint == 0 & Speed >= 0)
+                {
+                    if (Speed == 0)
+                    {
+                        # Avoid division by zero.
+                        SetPointSpeedCompensation = 0
+                    }
+                    else
+                    {
+                        # Locomotive is stopping & going uphill.
+                        SetPointSpeedCompensation = 0.1 / Speed
+                    }
+                }
+                else
+                {
+                    if (Speed == 0)
+                    {
+                        # Avoid division by zero.
+                        SetPointSpeedCompensation = 0
+                    }
+                    else
+                    {
+                        # Locomotive is going forward & going uphill.
+                        SetPointSpeedCompensation = SetPoint / Speed
+                    }
+                }
+            }
+            elseif (Direction == -1)
+            {
+                if (SetPoint == 0 & Speed > 0)
+                {
+                    # Locomotive is stopping & going downhill.
+                    SetPointSpeedCompensation = Speed / 0.1
+                }
+                else
+                {
+                    if (SetPoint == 0)
+                    {
+                        # Avoid division by zero.
+                        SetPointSpeedCompensation = 0
+                    }
+                    else
+                    {
+                        # Locomotive is reversing & going downhill.
+                        SetPointSpeedCompensation = Speed / SetPoint
+                    }
+                }
+            }
+        }
+        else
+        {
+            if (Direction == 1)
+            {
+                if (SetPoint == 0 & Speed > 0)
+                {
+                    # Locomotive is stopping & going downhill.
+                    SetPointSpeedCompensation = Speed / 0.1
+                }
+                else
+                {
+                    if (SetPoint == 0)
+                    {
+                        # Avoid division by zero.
+                        SetPointSpeedCompensation = 0
+                    }
+                    else
+                    {
+                        # Locomotive is going forward & going downhill.
+                        SetPointSpeedCompensation = Speed / SetPoint
+                    }
+                }
+            }
+            elseif (Direction == -1)
+            {
+                if (SetPoint == 0 & Speed >= 0)
+                {
+                    if (Speed == 0)
+                    {
+                        # Avoid division by zero.
+                        SetPointSpeedCompensation = 0
+                    }
+                    else
+                    {
+                        # Locomotive is stopping & going uphill.
+                        SetPointSpeedCompensation = 0.1 / Speed
+                    }
+                }
+                else
+                {
+                    if (Speed == 0)
+                    {
+                        # Avoid division by zero.
+                        SetPointSpeedCompensation = 0
+                    }
+                    else
+                    {
+                        # Locomotive is reversing & going uphill.
+                        SetPointSpeedCompensation = SetPoint / Speed
+                    }
+                }
+            }
+        }
+
+        # Now, calculate the hill climb & descent feedforward.
+        HillClimbDescentFF = (Gradient * SetPointSpeedCompensation) * Direction
+    }
+
+    pidSetFeedforward(S, "hill climb/descent", HillClimbDescentFF)
 }
 
 # Temporary placement of I Term Relax function, until I can decide to yeet it later.
@@ -649,6 +795,12 @@ function number pidGetIterm(S:table)
 function number pidGetDterm(S:table)
 {
     return S["D-Term", number]
+}
+
+# This function returns the current value of the hill climb/descent feedforward.
+function number pidGetFFhillClimbDescent(S:table)
+{
+    return S["FF Hill Climb/Descent", number]
 }
 
 # This function returns the current value of the Feedforward Sum.

--- a/lib/sensors/ndof.txt
+++ b/lib/sensors/ndof.txt
@@ -42,101 +42,152 @@
         - Gyroscope: 100 Hz
         - Magnetometer: 20 Hz
         - Orientation Sensor: 50 Hz
-    
-    Notes:
-    Just like the speedometer, the 9DOF Sensor Library uses differential inputs per sensor axis.
-    These differential inputs are sourced from the locomotive's trucks, & are used to detect the locomotive's orientation,
-    acceleration, and angular velocity.
-    The orientation sensor is a fusion of the accelerometer, gyroscope, and magnetometer.
-
-    The Orientation Sensor, provides a quaternion (x, y, z, w) that represents the locomotive's orientation.
-    The quaternion is used to calculate the locomotive's pitch, roll, and yaw angles (in degrees).
-    Doing it this way over using Euler angles, allows for a more accurate representation of the locomotive's orientation
-    in 3D space, & it prevents gimbal lock - which is a problem that occurs when Euler angles are close to 90° or -90°.
-    Pitch angle data is used in RailDriver's PID Controller to detect when the locomotive is climbing or descending a hill,
-    & to provide a feedforward term to the PID Controller.
-
-    Acceleration is calculated by taking the difference between the current and previous sensor values.
-    The difference is then divided by the time it took to get the difference.
-    This gives me the acceleration in m/s^2 (meters per second squared).
-    The acceleration is used to detect when the locomotive is moving.
-    It can be used by other parts of RailDriver to detect when the locomotive is accelerating or decelerating.
-    For example, RailDriver's PID Controller can use the acceleration data as its process variable.
-    Thus, allowing the driver to control the locomotive's speed through the acceleration of the locomotive.
-    This lays the groundwork for RailDriver's implementation of the Acceleration Mode of its PID Controller.
-    Thus, providing the driver with a more traditional railroad engineering experience.
-
-    Angular velocity is calculated by taking the difference between the current and previous sensor values.
-    The difference is then divided by the time it took to get the difference.
-    This gives us the angular velocity in deg/s (degrees per second).
-    The angular velocity is used to detect when the locomotive is turning.
-    It can be used by RailDriver's PID Controller to detect when the locomotive is turning, & to provide a feedforward term
-    to the PID Controller to aid in the locomotive's cornering performance.
-
-    Timing:
-    Because Garry's Mod's E2s are single-threaded, we can't use the E2's built-in timer functions to poll the sensors.
-    The other reason why this is not possible is because the E2's built-in timer functions are not precise enough & the game
-    tick itself is not fast enough to poll the sensors at the desired rate.
-
-    Instead, I am creating a custom timer that measures the execution time of the sensor loop in microseconds.
-    The timer is then used to calculate the time it took to execute the sensor loop. This is used to calculate the
-    delta time (dt) in seconds. Thus, allowing me to calculate my desired polling rate & to calculate my sensor values.
-
-    I know for a fact that E2 hates standard ```while``` & ```for``` loops. So, I am supplementing the conditionals in the
-    ```while``` loop with a ```perf()``` function. This function helps to prevent the E2 from crashing, with the trade-off
-    of a loss in sensor polling rate.
-    To work around this, I am doing a burst of sensor polling once every 500 ms. This burst of sensor polling is done
-    to ensure that the sensor values are updated at the desired rate & are as accurate as possible without crashing the E2.
-
-    RailDriver's PID Controller executes roughly every 10 ticks. This means that the PID Controller is executed roughly
-    every 150 ms in single-player, & every 300 ms in multiplayer. This is why I am doing a burst of sensor polling instead
-    of continuously polling the sensors at their desired rates.
-
-    To reduce the impact on the E2's performance, I am only doing a burst of sensor polling inside one loop, as opposed to
-    using multiple consecutive loops. This also prevents staggered bursts of sensor polling, which would cause the sensor
-    values to be updated at different times. As a result, the sensor values would be less accurate & the PID Controller
-    would be less responsive.
-    Using a single loop also allows me to use a single timer to calculate the time it took to execute the sensor loop.
-    Thus, improving the accuracy of the sensor values.
-
-    Filtering:
-    In RailDriver's Speedometer Library, I used a low-pass filter to smooth out the speedometer's output.
-    At this point, I may or may not use a low-pass filter here, considering that I am using burst sensor polling.
-    I may use a low-pass filter to smooth out the sensor values, but I am not sure if it is necessary.
-    However, I will still write the code for the low-pass filter, just in case I decide to use it when I am testing the
-    9DOF Sensor Library in the future.
-
-    A low-pass filter is a filter that passes low-frequency signals, but attenuates (reduces) high-frequency signals.
-    A low-pass filter is used to smooth out the sensor values, & to reduce noise in the sensor values.
-    The low-pass filter is implemented as a recursive filter, which is a filter that uses the previous output as the input
-    for the next iteration of the filter.
-    The low-pass filter is implemented as a recursive filter, because it is more efficient than an iterative filter.
-
-    Math:
-    The math used in this library is based on real-world physics & engineering principles that are used in the real world.
-    I am using the same math that I learned with my studies in control systems engineering & mechanical engineering.
-    Also, the math that I am using is based on the same control theory that I taught myself when I was working on some of my
-    older projects, such as my old Vector Controller E2, Fantail Flybarless (an IRL RC helicopter stabilization system
-    that I designed & built, as a precursor to another project that I am currently helping to develop - RotorFlight), & my
-    old Smart Locomotive Controller E2 (which is the 2016 predecessor to RailDriver).
-    
-    For processing the sensor values, I will be using an improved version of the math that I used for my 3D Mouse Project from
-    2017. That project was a 3D mouse that I designed & built, & it was used to control my computer's mouse cursor in 3D
-    space. The mouse itself was connected to my computer via Bluetooth, & it used a 9-axis IMU (Inertial Measurement Unit)
-    to detect the mouse's orientation, acceleration, & angular velocity. It used a Cortex-M4 microcontroller to process the
-    sensor values, & it used a Bluetooth module to send the sensor values to my computer. All of the components could be
-    obtained from Adafruit, & the project was open-source. I never released the project, because I was working on other
-    projects at the time, & I never got around to finishing it. The hardware that it used at the time was very new & cutting
-    edge technology, & it was very expensive. Now, that hardware has become obsolete & 3D mice in general are very much
-    outdated, it would be very difficult to replicate the project, let alone maintain it or improve it.
-    Even if I did finish the project, I would not have released it, because I was not happy with the way that I implemented
-    the sensor processing. I was using a very simple & naive implementation of the sensor processing, & I was not using
-    the sensor values to their full potential. Also, at the time, I wasn't using FreeRTOS, which is a real-time operating
-    system that I now use for literally all of my embedded systems projects. Looking back on that project, it makes me wonder
-    how I was able to get it to work at all, considering the entire code was a total mess & single-threaded, no less.
-
-    Anyways, I digress.
-    The math that I am using in this library comes from a diverse palette of sources, such as my studies in control systems
-    engineering, mechanical engineering, my own personal projects, my own research, development & testing.
-    Any additional sources that I have, I will attribute them accordingly.
 ]#
+
+# This function initializes the 9DOF Sensor Library.
+# This function must be called before any other functions in the library can be used.
+# @param Trucks An array of the trucks that the sensor library will be used on.
+# @return Ndof A handle to the 9DOF Sensor Library.
+function table ndofInit(Trucks:array)
+{
+    assert(Trucks:count() == 2, "9DoF Sensor Library requires 2 trucks.")
+
+    local NdofSensor = table()
+
+    # Differential Input
+    NdofSensor["Differential Input - Positive", entity] = Trucks[1, entity]
+    NdofSensor["Differential Input - Negative", entity] = Trucks[2, entity]
+
+    # Timings
+    NdofSensor["Sensor Loop - Timer", string] = "Sensor Loop Timer"
+    NdofSensor["Sensor Loop - Interval", number] = 500
+    NdofSensor["Sensor Loop - Burst Count", number] = 0
+    NdofSensor["Sensor Loop - Burst Count Max", number] = 10
+    NdofSensor["Sensor Loop - Burst Interval", number] = NdofSensor["Sensor Loop - Interval", number] / NdofSensor["Sensor Loop - Burst Count Max", number]
+
+    NdofSensor["Sensor Loop - Current Time", number] = systime()
+    NdofSensor["Sensor Loop - Previous Time", number] = systime()
+    NdofSensor["Sensor Loop - Time Difference", number] = 0
+
+    # Totoal timing interval must not exceed 1000ms (1 second).
+    local TotalInterval = NdofSensor["Sensor Loop - Interval", number] + NdofSensor["Sensor Loop - Burst Interval", number]
+    assert(TotalInterval <= 1000, "Total timing interval must not exceed 1000ms (1 second).")
+
+    # Accelerometer
+    NdofSensor["Accelerometer - Current Speed", vector] = vec()
+    NdofSensor["Accelerometer - Previous Speed", vector] = vec()
+    NdofSensor["Accelerometer - Acceleration", vector] = vec()
+
+    return NdofSensor
+}
+
+# This function starts the 9DOF Sensor Library.
+# This function must be called after the 9DOF Sensor Library has been initialized.
+# @param Ndof A handle to the 9DOF Sensor Library.
+function void ndofStartSensorLoop(Ndof:table)
+{
+    timer(Ndof["Sensor Loop - Timer", string], Ndof["Sensor Loop - Interval", number])
+}
+
+# This function returns the sensor loop's timer identifier.
+# @param Ndof A handle to the 9DOF Sensor Library.
+# @return Timer A string containing the sensor loop's timer identifier.
+function string ndofGetClockId(Ndof:table)
+{
+    return Ndof["Sensor Loop - Timer", string]
+}
+
+# This function manages the sensor loop's execution timing.
+# This function must be called every time the sensor loop's timer expires.
+# @param Ndof A handle to the 9DOF Sensor Library.
+# @return void
+function void ndofSensorLoop(Ndof:table)
+{
+    local CurrentTime = systime() * 1000
+    local TimeDifference = CurrentTime - Ndof["Sensor Loop - Previous Time", number]
+    Ndof["Sensor Loop - Time Difference", number] = TimeDifference
+
+    if (TimeDifference >= Ndof["Sensor Loop - Interval", number])
+    {
+        Ndof["Sensor Loop - Burst Count", number] = 0
+        Ndof["Sensor Loop - Previous Time", number] = CurrentTime
+    }
+    else
+    {
+        Ndof["Sensor Loop - Burst Count", number] = Ndof["Sensor Loop - Burst Count", number] + 1
+    }
+
+    stoptimer(Ndof["Sensor Loop - Timer", string])
+
+    if (Ndof["Sensor Loop - Burst Count", number] < Ndof["Sensor Loop - Burst Count Max", number])
+    {
+        timer(Ndof["Sensor Loop - Timer", string], Ndof["Sensor Loop - Burst Interval", number])
+    }
+    else
+    {
+        timer(Ndof["Sensor Loop - Timer", string], Ndof["Sensor Loop - Interval", number])
+    }
+}
+
+# This function stops the sensor loop.
+# @param Ndof A handle to the 9DOF Sensor Library.
+# @return void
+function void ndofStopSensorLoop(Ndof:table)
+{
+    stoptimer(Ndof["Sensor Loop - Timer", string])
+}
+
+# This function gets the acceleration, angular velocity, & orientation of the trucks.
+# This function must be called every tick.
+# @param Ndof A handle to the 9DOF Sensor Library.
+# @return SensorValues An array of vectors containing the acceleration, angular velocity, & orientation of the trucks.
+function array ndofGetSensorValues(Ndof:table)
+{
+    local SensorValues = array(vec(), ang(), ang())
+    local T1 = Ndof["Differential Input - Positive", entity]
+    local T2 = Ndof["Differential Input - Negative", entity]
+
+    # Acceleration
+    local Acceleration = vec()
+    local CurrentSpeed = vec()
+
+    CurrentSpeed = CurrentSpeed:setX(T1:velL():x())
+    CurrentSpeed = CurrentSpeed:setY(T1:velL():y())
+    CurrentSpeed = CurrentSpeed:setZ(T1:velL():z())
+
+    Acceleration = Acceleration:setX((CurrentSpeed:x() - Ndof["Accelerometer - Previous Speed", vector]:x()) / Ndof["Sensor Loop - Time Difference", number] * 1000)
+    Acceleration = Acceleration:setY((CurrentSpeed:y() - Ndof["Accelerometer - Previous Speed", vector]:y()) / Ndof["Sensor Loop - Time Difference", number] * 1000)
+    Acceleration = Acceleration:setZ((CurrentSpeed:z() - Ndof["Accelerometer - Previous Speed", vector]:z()) / Ndof["Sensor Loop - Time Difference", number] * 1000)
+
+    Ndof["Accelerometer - Previous Speed", vector] = CurrentSpeed
+
+    SensorValues[1, vector] = Acceleration
+
+    # Angular Velocity
+    local AngularVelocity = ang()
+
+    AngularVelocity = AngularVelocity:setPitch(T1:angVel():pitch())
+    AngularVelocity = AngularVelocity:setYaw(T1:angVel():yaw())
+    AngularVelocity = AngularVelocity:setRoll(T1:angVel():roll())
+
+    SensorValues[2, angle] = AngularVelocity
+
+    # Orientation
+    local Orientation = ang()
+
+    Orientation = Orientation:setPitch(T1:angles():pitch())
+    Orientation = Orientation:setYaw(T1:angles():yaw())
+    Orientation = Orientation:setRoll(T1:angles():roll())
+
+    SensorValues[3, angle] = Orientation
+
+    return SensorValues
+}
+
+# This function gets the time difference between the current time and the previous time.
+# @param Ndof A handle to the 9DOF Sensor Library.
+# @return TimeDifference A number containing the time difference between the current time and the previous time.
+function number ndofGetTimeDelta(Ndof:table)
+{
+    return Ndof["Sensor Loop - Time Difference", number]
+}

--- a/lib/sensors/ndof.txt
+++ b/lib/sensors/ndof.txt
@@ -1,0 +1,142 @@
+#[
+    This script header is a part of RailDriver.
+
+    RailDriver. Smart Locomotive Control script for Garry's Mod Train Build Servers.
+    Copyright © 2022, Cassandra "ZZ Cat" Robinson. All rights reserved.
+
+    This E2 script is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This E2 script is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this E2 script.  If not, see <https://www.gnu.org/licenses/>.
+]#
+
+@name RailDriver/lib/sensors/ndof
+
+#[
+    9DOF Sensor Library
+
+    This library is used to detect the orientation, acceleration, and angular velocity of the locomotive.
+    It is used to detect the locomotive's orientation and speed, and to detect when the locomotive is moving.
+
+    Sensors:
+        - Accelerometer (3-axis)
+        - Gyroscope (3-axis)
+        - Magnetometer (3-axis)
+        - Orientation Sensor (fusion of accelerometer, gyroscope, and magnetometer)
+    
+    Units:
+        - Acceleration: m/s^2 (meters per second squared)
+        - Angular Velocity: deg/s (degrees per second)
+        - Orientation: Quaternion (x, y, z, w)
+    
+    Polling:
+        - Accelerometer: 100 Hz
+        - Gyroscope: 100 Hz
+        - Magnetometer: 20 Hz
+        - Orientation Sensor: 50 Hz
+    
+    Notes:
+    Just like the speedometer, the 9DOF Sensor Library uses differential inputs per sensor axis.
+    These differential inputs are sourced from the locomotive's trucks, & are used to detect the locomotive's orientation,
+    acceleration, and angular velocity.
+    The orientation sensor is a fusion of the accelerometer, gyroscope, and magnetometer.
+
+    The Orientation Sensor, provides a quaternion (x, y, z, w) that represents the locomotive's orientation.
+    The quaternion is used to calculate the locomotive's pitch, roll, and yaw angles (in degrees).
+    Doing it this way over using Euler angles, allows for a more accurate representation of the locomotive's orientation
+    in 3D space, & it prevents gimbal lock - which is a problem that occurs when Euler angles are close to 90° or -90°.
+    Pitch angle data is used in RailDriver's PID Controller to detect when the locomotive is climbing or descending a hill,
+    & to provide a feedforward term to the PID Controller.
+
+    Acceleration is calculated by taking the difference between the current and previous sensor values.
+    The difference is then divided by the time it took to get the difference.
+    This gives me the acceleration in m/s^2 (meters per second squared).
+    The acceleration is used to detect when the locomotive is moving.
+    It can be used by other parts of RailDriver to detect when the locomotive is accelerating or decelerating.
+    For example, RailDriver's PID Controller can use the acceleration data as its process variable.
+    Thus, allowing the driver to control the locomotive's speed through the acceleration of the locomotive.
+    This lays the groundwork for RailDriver's implementation of the Acceleration Mode of its PID Controller.
+    Thus, providing the driver with a more traditional railroad engineering experience.
+
+    Angular velocity is calculated by taking the difference between the current and previous sensor values.
+    The difference is then divided by the time it took to get the difference.
+    This gives us the angular velocity in deg/s (degrees per second).
+    The angular velocity is used to detect when the locomotive is turning.
+    It can be used by RailDriver's PID Controller to detect when the locomotive is turning, & to provide a feedforward term
+    to the PID Controller to aid in the locomotive's cornering performance.
+
+    Timing:
+    Because Garry's Mod's E2s are single-threaded, we can't use the E2's built-in timer functions to poll the sensors.
+    The other reason why this is not possible is because the E2's built-in timer functions are not precise enough & the game
+    tick itself is not fast enough to poll the sensors at the desired rate.
+
+    Instead, I am creating a custom timer that measures the execution time of the sensor loop in microseconds.
+    The timer is then used to calculate the time it took to execute the sensor loop. This is used to calculate the
+    delta time (dt) in seconds. Thus, allowing me to calculate my desired polling rate & to calculate my sensor values.
+
+    I know for a fact that E2 hates standard ```while``` & ```for``` loops. So, I am supplementing the conditionals in the
+    ```while``` loop with a ```perf()``` function. This function helps to prevent the E2 from crashing, with the trade-off
+    of a loss in sensor polling rate.
+    To work around this, I am doing a burst of sensor polling once every 500 ms. This burst of sensor polling is done
+    to ensure that the sensor values are updated at the desired rate & are as accurate as possible without crashing the E2.
+
+    RailDriver's PID Controller executes roughly every 10 ticks. This means that the PID Controller is executed roughly
+    every 150 ms in single-player, & every 300 ms in multiplayer. This is why I am doing a burst of sensor polling instead
+    of continuously polling the sensors at their desired rates.
+
+    To reduce the impact on the E2's performance, I am only doing a burst of sensor polling inside one loop, as opposed to
+    using multiple consecutive loops. This also prevents staggered bursts of sensor polling, which would cause the sensor
+    values to be updated at different times. As a result, the sensor values would be less accurate & the PID Controller
+    would be less responsive.
+    Using a single loop also allows me to use a single timer to calculate the time it took to execute the sensor loop.
+    Thus, improving the accuracy of the sensor values.
+
+    Filtering:
+    In RailDriver's Speedometer Library, I used a low-pass filter to smooth out the speedometer's output.
+    At this point, I may or may not use a low-pass filter here, considering that I am using burst sensor polling.
+    I may use a low-pass filter to smooth out the sensor values, but I am not sure if it is necessary.
+    However, I will still write the code for the low-pass filter, just in case I decide to use it when I am testing the
+    9DOF Sensor Library in the future.
+
+    A low-pass filter is a filter that passes low-frequency signals, but attenuates (reduces) high-frequency signals.
+    A low-pass filter is used to smooth out the sensor values, & to reduce noise in the sensor values.
+    The low-pass filter is implemented as a recursive filter, which is a filter that uses the previous output as the input
+    for the next iteration of the filter.
+    The low-pass filter is implemented as a recursive filter, because it is more efficient than an iterative filter.
+
+    Math:
+    The math used in this library is based on real-world physics & engineering principles that are used in the real world.
+    I am using the same math that I learned with my studies in control systems engineering & mechanical engineering.
+    Also, the math that I am using is based on the same control theory that I taught myself when I was working on some of my
+    older projects, such as my old Vector Controller E2, Fantail Flybarless (an IRL RC helicopter stabilization system
+    that I designed & built, as a precursor to another project that I am currently helping to develop - RotorFlight), & my
+    old Smart Locomotive Controller E2 (which is the 2016 predecessor to RailDriver).
+    
+    For processing the sensor values, I will be using an improved version of the math that I used for my 3D Mouse Project from
+    2017. That project was a 3D mouse that I designed & built, & it was used to control my computer's mouse cursor in 3D
+    space. The mouse itself was connected to my computer via Bluetooth, & it used a 9-axis IMU (Inertial Measurement Unit)
+    to detect the mouse's orientation, acceleration, & angular velocity. It used a Cortex-M4 microcontroller to process the
+    sensor values, & it used a Bluetooth module to send the sensor values to my computer. All of the components could be
+    obtained from Adafruit, & the project was open-source. I never released the project, because I was working on other
+    projects at the time, & I never got around to finishing it. The hardware that it used at the time was very new & cutting
+    edge technology, & it was very expensive. Now, that hardware has become obsolete & 3D mice in general are very much
+    outdated, it would be very difficult to replicate the project, let alone maintain it or improve it.
+    Even if I did finish the project, I would not have released it, because I was not happy with the way that I implemented
+    the sensor processing. I was using a very simple & naive implementation of the sensor processing, & I was not using
+    the sensor values to their full potential. Also, at the time, I wasn't using FreeRTOS, which is a real-time operating
+    system that I now use for literally all of my embedded systems projects. Looking back on that project, it makes me wonder
+    how I was able to get it to work at all, considering the entire code was a total mess & single-threaded, no less.
+
+    Anyways, I digress.
+    The math that I am using in this library comes from a diverse palette of sources, such as my studies in control systems
+    engineering, mechanical engineering, my own personal projects, my own research, development & testing.
+    Any additional sources that I have, I will attribute them accordingly.
+]#

--- a/lib/sensors/ndof.txt
+++ b/lib/sensors/ndof.txt
@@ -175,9 +175,9 @@ function array ndofGetSensorValues(Ndof:table)
     # Orientation
     local Orientation = ang()
 
-    Orientation = Orientation:setPitch(T1:angles():pitch())
-    Orientation = Orientation:setYaw(T1:angles():yaw())
-    Orientation = Orientation:setRoll(T1:angles():roll())
+    Orientation = Orientation:setPitch(-T1:angles():roll())
+    Orientation = Orientation:setYaw(-T1:angles():yaw())
+    Orientation = Orientation:setRoll(T1:angles():pitch())
 
     SensorValues[3, angle] = Orientation
 

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -213,7 +213,7 @@ function number semDirectControlTrucks(Trucks:array, PIDFOutput:number, Reverser
     }
 
     # Calculate the traction motor output.
-    local MotorOutput = PIDFOutput * Reverser
+    local MotorOutput = PIDFOutput # * Reverser
 
     # Apply the traction motor output to the trucks.
     Trucks[1, entity]:applyForce(Trucks[1, entity]:toWorldAxis(vec(0, -MotorOutput, 0)))


### PR DESCRIPTION
## Overview

This Pull Request implements #55.
Hill Climb/Descent Feedforward assists the locomotive's control loop when your train is climbing or descending hills.
Additionally, this feedforward assists the control loop during braking when you are on a hill.

When tuned correctly, this greatly reduces the chances of things like the I-Term becoming saturated (when the I-Term is saturated, the control loop is unable to effectively maintain your train's speed).

## What's new

- 9DoF Sensor Library.
  - This provides orientation, acceleration & angular velocity sensor data for RailDriver.
  - Track Gradient is calculated from the Pitch Orientation data from this library.
  - This lays the groundwork for an upcoming feature for RailDriver's control loop where you're controlling the locomotive's acceleration instead of your desired set speed. This lends itself to a more traditional railroad engineering experience, for those that are more accustomed to it.
 - Hill Climb/Descent Feedforward.
    - Inputs to this are sourced from the locomotive's speed, the track's gradient, the locomotive's direction, & the control loop's set point.
- Primary Feedforward.
  - This is a percentage of the total feedforward sum to the control loop.
Global adjustments to the feedforward component of the control loop is done with this gain. It has a limited value between 0% & 100%. By default, it is set to 100% & you need to tune the individual gains for each feedforward component _before_ you make any adjustments to this gain.