### PR TITLE
Engage Automatic Brake when the train has stopped

### DIFF
--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -98,7 +98,7 @@ if (RailDriverState == 1)
     local PIDOutputLimit = 75000
 
     local SpeedometerFilterCutoffFrequency = 1
-    local SpeedometerDeadband = 0.1
+    local SpeedometerDeadband = 2.0
 
     try
     {

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -89,8 +89,8 @@ if (RailDriverState == 1)
     local PIDCoefficientFFprimary = 100
     local PIDCoefficientFFhillclimb = 5500
 
-    local PIDItermDecayRate = 0.5
-    local PIDItermDecayThreshold = 3.0 * 17.6
+    local PIDItermDecayRate = 0.3
+    local PIDItermDecayThreshold = 7.0 * 17.6
     local PIDItermDecayHysteresis = 1
 
     local PIDFeedforwardLimit = 20000

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -669,9 +669,9 @@ elseif (RailDriverState == 2)
                 semControlTrucks(Trucks, Throttle, Brake, Reverser)
             ]#
 
-            # Set the brakes, if the train is not moving, the setpoint is 0, and the Emergency Brake is not active.
+            # Set the brakes, if the train is not moving & the setpoint is 0.
             # This is to prevent the train from rolling away. Fixes #65.
-            if (SpeedAbs == 0 & pidGetSetPoint(PIDF) == 0 & EmBrakeState == 0)
+            if (SpeedAbs == 0 & pidGetSetPoint(PIDF) == 0)
             {
                 # Set the train brakes to 100%.
                 semDirectControlBrakes(Trucks, 1)
@@ -679,8 +679,12 @@ elseif (RailDriverState == 2)
 
             else
             {
-                # Set the train brakes to 0%.
-                semDirectControlBrakes(Trucks, 0)
+                # Release the brakes, if the Emergency Brake is not active.
+                if (EmBrakeState == 0)
+                {
+                    # Set the train brakes to 0%.
+                    semDirectControlBrakes(Trucks, 0)
+                }
             }
 
             # Apply the PIDF Controller's output directly to the locomotive's traction motors.
@@ -1001,9 +1005,6 @@ elseif (RailDriverState == 2)
                     # Set the locomotive's traction motors to 0.
                     semDirectControlTrucks(Trucks, 0)
 
-                    # Set the locomotive's brakes to 0.
-                    semDirectControlBrakes(Trucks, 0)
-
                     # Re-enable the PIDF controller.
                     pidSetMode(PIDF, "Automatic")
                     runOnTick(1)
@@ -1025,7 +1026,7 @@ elseif (RailDriverState == 2)
 
                 # Freeze the entire train.
                 semFreezeTrain()
-                semDirectControlBrakes(Trucks, 0)
+                semDirectControlBrakes(Trucks, 1)
 
             # Set the Emergency Brake state to 0.
             EmBrakeState = 0

--- a/RailDriver.txt
+++ b/RailDriver.txt
@@ -669,6 +669,20 @@ elseif (RailDriverState == 2)
                 semControlTrucks(Trucks, Throttle, Brake, Reverser)
             ]#
 
+            # Set the brakes, if the train is not moving, the setpoint is 0, and the Emergency Brake is not active.
+            # This is to prevent the train from rolling away. Fixes #65.
+            if (SpeedAbs == 0 & pidGetSetPoint(PIDF) == 0 & EmBrakeState == 0)
+            {
+                # Set the train brakes to 100%.
+                semDirectControlBrakes(Trucks, 1)
+            }
+
+            else
+            {
+                # Set the train brakes to 0%.
+                semDirectControlBrakes(Trucks, 0)
+            }
+
             # Apply the PIDF Controller's output directly to the locomotive's traction motors.
             if (!semDirectControlTrucks(Trucks, PIDFOutput))
             {

--- a/lib/ota/version.json
+++ b/lib/ota/version.json
@@ -15,7 +15,7 @@
             "File":"RailDriver.txt",
             "Path":"e2shared/RailDriver",
             "Version":"0.1.0",
-            "Hash":"3312963174"
+            "Hash":"2211100172"
         },
         "Libraries":
         {

--- a/lib/ota/version.json
+++ b/lib/ota/version.json
@@ -15,7 +15,7 @@
             "File":"RailDriver.txt",
             "Path":"e2shared/RailDriver",
             "Version":"0.1.0",
-            "Hash":"3989607944"
+            "Hash":"3312963174"
         },
         "Libraries":
         {

--- a/lib/ota/version.json
+++ b/lib/ota/version.json
@@ -15,7 +15,7 @@
             "File":"RailDriver.txt",
             "Path":"e2shared/RailDriver",
             "Version":"0.1.0",
-            "Hash":"2211100172"
+            "Hash":"406490754"
         },
         "Libraries":
         {

--- a/lib/ota/version.json
+++ b/lib/ota/version.json
@@ -15,7 +15,7 @@
             "File":"RailDriver.txt",
             "Path":"e2shared/RailDriver",
             "Version":"0.1.0",
-            "Hash":"4198609278"
+            "Hash":"3989607944"
         },
         "Libraries":
         {
@@ -82,7 +82,7 @@
                 "File":"smartEntityManagement.txt",
                 "Path":"e2shared/RailDriver/lib",
                 "Version":"0.1.0",
-                "Hash":"639861250"
+                "Hash":"1288505457"
             },
             "Timers":
             {

--- a/lib/smartEntityManagement.txt
+++ b/lib/smartEntityManagement.txt
@@ -20,6 +20,7 @@
 
 @name RailDriver/lib/smartEntityManagement
 @persist SemE2Locked [SemE2IsWeldedTo SemE2IsParentedTo SemE2]:entity
+@persist SemLastBrakeBrakeLevel:number
 
 function number semInit()
 {
@@ -27,6 +28,7 @@ function number semInit()
     SemE2 = entity()
     SemE2IsWeldedTo = SemE2:isWeldedTo()
     SemE2IsParentedTo = SemE2:parent()
+    SemLastBrakeBrakeLevel = -1
     return 1
 }
 
@@ -225,6 +227,12 @@ function number semDirectControlBrakes(Trucks:array, BrakeLevel:number)
         return 0
     }
 
+    # If the brake level is the same as the last brake level, then return.
+    if (BrakeLevel == SemLastBrakeBrakeLevel)
+    {
+        return 1
+    }
+
     # Find all of the trucks in the entire train.
     # This is necessary because the brakes are applied to the entire train, not just the locomotive.
     # This is done by finding all connected entities in the train.
@@ -310,6 +318,8 @@ function number semDirectControlBrakes(Trucks:array, BrakeLevel:number)
         break
     }
 
+    # Store the brake level for the next time this function is called.
+    SemLastBrakeBrakeLevel = BrakeLevel
 
     # Return true.
     return 1


### PR DESCRIPTION
## Overview

This Pull Request fixes #65.

## What's New

When the entire train has stopped, the brakes are automatically engaged & set to a 'rest' position.
This prevents the train from running away, when stopping on hills.

## How it works

The physical material of all of the trucks in the train are set to `phx_tire_normal` when the train is not moving.
When the driver commands the train to move again, the physical material of all of the trucks in the train are set to `friction_00`.

The Emergency Braking System overrides this Automatic Brake to allow the train to stop safely under Emergency Conditions.