### PR TITLE
refactor(main): :recycle: AdvDupe2 Compatibility

### DIFF
--- a/src/main/main.txt
+++ b/src/main/main.txt
@@ -1,0 +1,71 @@
+@name RailDriver
+@model models/beer/wiremod/gate_e2_nano.mdl
+# Advanced Duplicator properties
+@persist [Dupe_state Dupe_loading_tick_interval E2_runtime_state]
+@strict
+
+if (duped())
+{
+    Dupe_state = 1
+    Dupe_loading_tick_interval = tickInterval() * 1000
+    E2_runtime_state = 0
+    timer("dupe load watchdog", Dupe_loading_tick_interval)
+}
+elseif (dupefinished())
+{
+    Dupe_state = 2
+    E2_runtime_state = 0
+}
+elseif (clk("dupe load watchdog"))
+{
+    stoptimer("dupe load watchdog")
+    
+    if (Dupe_state == 1)
+    {
+        # Dupe is still loading. Restart the watchdog timer.
+        timer("dupe load watchdog", Dupe_loading_tick_interval)
+    }
+    elseif (Dupe_state == 2)
+    {
+        # Dupe has finished loading.
+        # Reset the E2 and start the main script.
+        reset()
+    }
+    else
+    {
+        # Error: E2 failed to load.
+        Dupe_state = 0
+        E2_runtime_state = 0
+        printColor(vec(255, 0, 0), "[RailDriver | FATAL ERROR]", vec(255), ": E2 script could not be loaded.")
+        exit()
+    }
+}
+elseif (first())
+{
+    # E2 script loaded successfully.
+    # Execute main runtime state machine.
+    E2_runtime_state = 1
+}
+
+event tick()
+{
+    if (E2_runtime_state == 1)
+    {
+        # Start main script.
+        E2_runtime_state = 2
+
+        # Print Welcome Message.
+        printColor(vec(255), "Welcome to RailDriver.")
+    }
+    elseif (E2_runtime_state == 2)
+    {
+        # Run main script.
+    }
+    else
+    {
+        # E2 core state machine is in an unknown state.
+        E2_runtime_state = 0
+        printColor(vec(255, 0, 0), "[RailDriver | FATAL ERROR]", vec(255), ": E2 runtime terminated with unknown state.")
+        exit()
+    }
+}

--- a/src/main/main.txt
+++ b/src/main/main.txt
@@ -4,7 +4,6 @@
 @persist [Dupe_state Dupe_loading_tick_interval E2_runtime_state]
 @strict
 
-#[#
 if (duped())
 {
     Dupe_state = 1
@@ -47,19 +46,10 @@ elseif (first())
     # Execute main runtime state machine.
     E2_runtime_state = 1
 }
-#]#
 
 event tick()
 {
-    if (E2_runtime_state == 0)
-    {
-        if (first())
-        {
-            # E2 runtime entry point.
-            Dupe_state = 0
-        }
-    }
-    elseif (E2_runtime_state == 1)
+    if (E2_runtime_state == 1)
     {
         # Start main script.
         E2_runtime_state = 2

--- a/src/main/main.txt
+++ b/src/main/main.txt
@@ -1,49 +1,21 @@
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
 # Advanced Duplicator properties
-@persist [Dupe_state Dupe_loading_tick_interval Dupe_loading_tick_timeout Dupe_loading_tick_count E2_runtime_state]
+@persist [Dupe_state Dupe_loading_tick_timeout Dupe_loading_tick_count E2_runtime_state]
 @strict
 
 if (duped())
 {
     Dupe_state = 1
-    Dupe_loading_tick_interval = tickInterval() * 1000
     Dupe_loading_tick_count = 0
     Dupe_loading_tick_timeout = 10
     E2_runtime_state = 0
-    # timer("dupe load watchdog", Dupe_loading_tick_interval)
 }
 elseif (dupefinished())
 {
     Dupe_state = 2
     E2_runtime_state = 0
 }
-#[#
-elseif (clk("dupe load watchdog"))
-{
-    stoptimer("dupe load watchdog")
-
-    if (Dupe_state == 1)
-    {
-        # Dupe is still loading. Restart the watchdog timer.
-        timer("dupe load watchdog", Dupe_loading_tick_interval)
-    }
-    elseif (Dupe_state == 2)
-    {
-        # Dupe has finished loading.
-        # Reset the E2 and start the main script.
-        reset()
-    }
-    else
-    {
-        # Error: E2 failed to load.
-        Dupe_state = 0
-        E2_runtime_state = 0
-        printColor(vec(255, 0, 0), "[RailDriver | FATAL ERROR]", vec(255), ": E2 script could not be loaded.")
-        exit()
-    }
-}
-#]#
 elseif (first())
 {
     # E2 script loaded successfully.
@@ -62,7 +34,7 @@ event tick()
             if (Dupe_state == 1)
             {
                 Dupe_loading_tick_count++
-                assert(Dupe_loading_tick_count < Dupe_loading_timeout, "Dupe loading timed out.")
+                assert(Dupe_loading_tick_count < Dupe_loading_tick_timeout, "Dupe loading timed out.")
             }
             elseif (Dupe_state == 2)
             {
@@ -90,9 +62,6 @@ event tick()
     else
     {
         # E2 core state machine is in an unknown state.
-        # E2_runtime_state = 0
-        # printColor(vec(255, 0, 0), "[RailDriver | FATAL ERROR]", vec(255), ": E2 runtime terminated with unknown state.")
-        # exit()
         error("E2 runtime state is unknown.")
     }
 }

--- a/src/main/main.txt
+++ b/src/main/main.txt
@@ -64,8 +64,8 @@ event tick()
     else
     {
         # E2 core state machine is in an unknown state.
-        E2_runtime_state = 0
-        printColor(vec(255, 0, 0), "[RailDriver | FATAL ERROR]", vec(255), ": E2 runtime terminated with unknown state.")
-        exit()
+        # E2_runtime_state = 0
+        # printColor(vec(255, 0, 0), "[RailDriver | FATAL ERROR]", vec(255), ": E2 runtime terminated with unknown state.")
+        # exit()
     }
 }

--- a/src/main/main.txt
+++ b/src/main/main.txt
@@ -4,6 +4,7 @@
 @persist [Dupe_state Dupe_loading_tick_interval E2_runtime_state]
 @strict
 
+#[#
 if (duped())
 {
     Dupe_state = 1
@@ -46,10 +47,19 @@ elseif (first())
     # Execute main runtime state machine.
     E2_runtime_state = 1
 }
+#]#
 
 event tick()
 {
-    if (E2_runtime_state == 1)
+    if (E2_runtime_state == 0)
+    {
+        if (first())
+        {
+            # E2 runtime entry point.
+            Dupe_state = 0
+        }
+    }
+    elseif (E2_runtime_state == 1)
     {
         # Start main script.
         E2_runtime_state = 2

--- a/src/main/main.txt
+++ b/src/main/main.txt
@@ -1,25 +1,28 @@
 @name RailDriver
 @model models/beer/wiremod/gate_e2_nano.mdl
 # Advanced Duplicator properties
-@persist [Dupe_state Dupe_loading_tick_interval E2_runtime_state]
+@persist [Dupe_state Dupe_loading_tick_interval Dupe_loading_tick_timeout Dupe_loading_tick_count E2_runtime_state]
 @strict
 
 if (duped())
 {
     Dupe_state = 1
     Dupe_loading_tick_interval = tickInterval() * 1000
+    Dupe_loading_tick_count = 0
+    Dupe_loading_tick_timeout = 10
     E2_runtime_state = 0
-    timer("dupe load watchdog", Dupe_loading_tick_interval)
+    # timer("dupe load watchdog", Dupe_loading_tick_interval)
 }
 elseif (dupefinished())
 {
     Dupe_state = 2
     E2_runtime_state = 0
 }
+#[#
 elseif (clk("dupe load watchdog"))
 {
     stoptimer("dupe load watchdog")
-    
+
     if (Dupe_state == 1)
     {
         # Dupe is still loading. Restart the watchdog timer.
@@ -40,16 +43,39 @@ elseif (clk("dupe load watchdog"))
         exit()
     }
 }
+#]#
 elseif (first())
 {
     # E2 script loaded successfully.
     # Execute main runtime state machine.
+    Dupe_state = 0
     E2_runtime_state = 1
 }
 
 event tick()
 {
-    if (E2_runtime_state == 1)
+    if (E2_runtime_state == 0)
+    {
+        # Run Duplicator timeout.
+        if (Dupe_state > 0)
+        {
+            if (Dupe_state == 1)
+            {
+                Dupe_loading_tick_count++
+                assert(Dupe_loading_tick_count < Dupe_loading_timeout, "Dupe loading timed out.")
+            }
+            elseif (Dupe_state == 2)
+            {
+                # Reset runtime.
+                reset()
+            }
+        }
+        else
+        {
+            error("E2 runtime not initialised")
+        }
+    }
+    elseif (E2_runtime_state == 1)
     {
         # Start main script.
         E2_runtime_state = 2
@@ -67,5 +93,6 @@ event tick()
         # E2_runtime_state = 0
         # printColor(vec(255, 0, 0), "[RailDriver | FATAL ERROR]", vec(255), ": E2 runtime terminated with unknown state.")
         # exit()
+        error("E2 runtime state is unknown.")
     }
 }


### PR DESCRIPTION
## Overview

This Pull Request reinstates Advanced Duplicator 2 compatibility and uses the new tick event handler for managing the Runtime State Machine.

## Details

The traditional `duped()`, `dupefinished()` and `first()` functions are used to initialise the runtime state, as well as tell the Runtime State Machine when to initialise the main Expression 2 script.

A timeout of 10 ticks is used in case loading the script times out.